### PR TITLE
Update MapScreen component with main buildings info

### DIFF
--- a/mobile-app/components/BuildingInfoModal.tsx
+++ b/mobile-app/components/BuildingInfoModal.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Modal, Pressable, StyleSheet, View } from 'react-native';
+import { Text, YStack, XStack } from 'tamagui';
+import type { MainBuilding } from '@/constants/campusBuildings';
+import { ConcordiaRed, ConcordiaRedMuted } from '@/constants/theme';
+
+interface BuildingInfoModalProps {
+  visible: boolean;
+  building: MainBuilding | null;
+  onClose: () => void;
+}
+
+export default function BuildingInfoModal({
+  visible,
+  building,
+  onClose,
+}: Readonly<BuildingInfoModalProps>) {
+  if (!building) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable style={styles.card} onPress={(e) => e.stopPropagation()}>
+          <View style={styles.cardAccent} />
+          <YStack padding="$4" gap="$3">
+            <XStack justifyContent="space-between" alignItems="flex-start" gap="$3">
+              <Text fontSize="$6" fontWeight="bold" style={styles.title} flex={1}>
+                {building.name}
+              </Text>
+              <View style={styles.codeBadge}>
+                <Text fontSize="$2" fontWeight="600" style={styles.codeText}>
+                  {building.code}
+                </Text>
+              </View>
+            </XStack>
+            {building.description ? (
+              <Text fontSize="$3" style={styles.description} lineHeight={22}>
+                {building.description}
+              </Text>
+            ) : null}
+            <Text fontSize="$2" style={styles.hint} marginTop="$2">
+              Tap outside to close
+            </Text>
+          </YStack>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 360,
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.18,
+    shadowRadius: 16,
+    elevation: 10,
+  },
+  cardAccent: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 4,
+    backgroundColor: ConcordiaRed,
+  },
+  title: {
+    color: '#11181C',
+  },
+  codeBadge: {
+    backgroundColor: ConcordiaRedMuted,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: ConcordiaRed,
+  },
+  codeText: {
+    color: ConcordiaRed,
+  },
+  description: {
+    color: '#444',
+  },
+  hint: {
+    color: '#687076',
+  },
+});

--- a/mobile-app/components/MapScreen.tsx
+++ b/mobile-app/components/MapScreen.tsx
@@ -1,22 +1,246 @@
-import React from "react";
-import { View } from "react-native";
-import MapView from "react-native-maps";
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  useWindowDimensions,
+} from 'react-native';
+import MapView from 'react-native-maps';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Text, XStack } from 'tamagui';
+import {
+  CAMPUS_BUILDINGS,
+  CAMPUS_IDS,
+  type CampusId,
+  type MainBuilding,
+} from '@/constants/campusBuildings';
+import { ConcordiaRed, ConcordiaRedMuted } from '@/constants/theme';
+import BuildingInfoModal from './BuildingInfoModal';
 
-// A simple map screen centered on SGW campus
+const CARD_MIN_WIDTH = 140;
+const CARD_GAP = 10;
+const FOOTER_HORIZONTAL_PADDING = 16;
 
 export default function MapScreen() {
-    return (
-        <View style={{ flex: 1 }}>
-            <MapView
-                style={{ flex: 1 }}
-                provider="google"
-                initialRegion={{
-                    latitude: 45.4973,     // SGW
-                    longitude: -73.5789,
-                    latitudeDelta: 0.01,
-                    longitudeDelta: 0.01,
-                }}
-            />
+  const [campusId, setCampusId] = useState<CampusId>('SGW');
+  const [selectedBuilding, setSelectedBuilding] = useState<MainBuilding | null>(
+    null
+  );
+  const [modalVisible, setModalVisible] = useState(false);
+  const mapRef = useRef<MapView>(null);
+  const { width: windowWidth } = useWindowDimensions();
+
+  const campus = CAMPUS_BUILDINGS[campusId];
+  const buildings = campus.buildings;
+
+  const handleCampusChange = useCallback((id: CampusId) => {
+    setCampusId(id);
+    const next = CAMPUS_BUILDINGS[id];
+    mapRef.current?.animateToRegion(next.region, 400);
+  }, []);
+
+  const openBuildingInfo = useCallback((building: MainBuilding) => {
+    setSelectedBuilding(building);
+    setModalVisible(true);
+  }, []);
+
+  const closeBuildingInfo = useCallback(() => {
+    setModalVisible(false);
+    setSelectedBuilding(null);
+  }, []);
+
+  const footerContentWidth = windowWidth - FOOTER_HORIZONTAL_PADDING * 2;
+  const cardWidth = Math.max(
+    CARD_MIN_WIDTH,
+    (footerContentWidth - CARD_GAP * 3) / 4
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.mapWrapper}>
+        <MapView
+          ref={mapRef}
+          style={StyleSheet.absoluteFill}
+          provider="google"
+          initialRegion={campus.region}
+          showsUserLocation
+          showsMyLocationButton
+        />
+      </View>
+
+      {/* Campus selector - above footer, doesn't overlap map controls */}
+      <View style={styles.campusSelector}>
+        <XStack gap="$2">
+          {CAMPUS_IDS.map((id) => (
+            <Pressable
+              key={id}
+              onPress={() => handleCampusChange(id)}
+              style={[
+                styles.campusChip,
+                campusId === id && styles.campusChipActive,
+              ]}
+            >
+              <Text
+                fontSize="$2"
+                fontWeight={campusId === id ? '600' : '500'}
+                color={campusId === id ? '#fff' : ConcordiaRed}
+              >
+                {id}
+              </Text>
+            </Pressable>
+          ))}
+        </XStack>
+      </View>
+
+      {/* Main Buildings footer bar */}
+      <SafeAreaView style={styles.footerWrapper} edges={['bottom']}>
+        <View style={styles.footerHeader}>
+          <View style={styles.footerHeaderAccent} />
+          <Text
+            fontSize="$2"
+            fontWeight="600"
+            color={ConcordiaRed}
+            letterSpacing={0.5}
+            paddingHorizontal={FOOTER_HORIZONTAL_PADDING}
+          >
+            Main Buildings
+          </Text>
         </View>
-    );
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={[
+            styles.footerScroll,
+            { paddingHorizontal: FOOTER_HORIZONTAL_PADDING },
+          ]}
+        >
+          {buildings.map((building) => (
+            <Pressable
+              key={building.id}
+              style={({ pressed }) => [
+                styles.buildingCard,
+                { width: cardWidth },
+                pressed && styles.buildingCardPressed,
+              ]}
+              onPress={() => openBuildingInfo(building)}
+            >
+              <View style={styles.buildingCardAccent} />
+              <Text
+                fontSize="$2"
+                fontWeight="600"
+                style={styles.buildingCardTitle}
+                numberOfLines={2}
+              >
+                {building.name}
+              </Text>
+              <Text
+                fontSize="$1"
+                fontWeight="500"
+                style={styles.buildingCardCode}
+              >
+                {building.code}
+              </Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+      </SafeAreaView>
+
+      <BuildingInfoModal
+        visible={modalVisible}
+        building={selectedBuilding}
+        onClose={closeBuildingInfo}
+      />
+    </SafeAreaView>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  mapWrapper: {
+    flex: 1,
+  },
+  campusSelector: {
+    position: 'absolute',
+    top: 8,
+    left: 16,
+    right: 16,
+    alignItems: 'center',
+  },
+  campusChip: {
+    paddingHorizontal: 16,
+    paddingVertical: 9,
+    borderRadius: 20,
+    backgroundColor: 'rgba(255,255,255,0.96)',
+    borderWidth: 1.5,
+    borderColor: ConcordiaRedMuted,
+  },
+  campusChipActive: {
+    backgroundColor: ConcordiaRed,
+    borderColor: ConcordiaRed,
+  },
+  footerWrapper: {
+    backgroundColor: '#fff',
+    paddingTop: 14,
+    paddingBottom: 10,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    borderTopWidth: 3,
+    borderTopColor: ConcordiaRed,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 12,
+    elevation: 10,
+  },
+  footerHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  footerHeaderAccent: {
+    width: 4,
+    height: 18,
+    backgroundColor: ConcordiaRed,
+    borderRadius: 2,
+    marginRight: 8,
+  },
+  footerScroll: {
+    flexDirection: 'row',
+    gap: CARD_GAP,
+    paddingBottom: 6,
+  },
+  buildingCard: {
+    backgroundColor: '#fff',
+    borderRadius: 14,
+    padding: 14,
+    paddingLeft: 18,
+    borderWidth: 1,
+    borderColor: ConcordiaRedMuted,
+    minHeight: 78,
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  buildingCardPressed: {
+    backgroundColor: ConcordiaRedMuted,
+  },
+  buildingCardAccent: {
+    position: 'absolute',
+    left: 0,
+    top: 12,
+    bottom: 12,
+    width: 3,
+    backgroundColor: ConcordiaRed,
+    borderRadius: 2,
+  },
+  buildingCardTitle: {
+    color: '#11181C',
+  },
+  buildingCardCode: {
+    color: ConcordiaRed,
+    marginTop: 6,
+  },
+});

--- a/mobile-app/constants/campusBuildings.ts
+++ b/mobile-app/constants/campusBuildings.ts
@@ -1,0 +1,102 @@
+/**
+ * Main buildings per campus for the map footer.
+ * Each campus has exactly 4 main buildings shown as quick-access cards.
+ */
+
+export type CampusId = 'SGW' | 'Loyola';
+
+export interface MainBuilding {
+  id: string;
+  name: string;
+  code: string; // Building code(s) shown on campus, e.g. "H", "HA, HB, HC"
+  description?: string;
+}
+
+export interface CampusBuildings {
+  id: CampusId;
+  name: string;
+  region: {
+    latitude: number;
+    longitude: number;
+    latitudeDelta: number;
+    longitudeDelta: number;
+  };
+  buildings: MainBuilding[];
+}
+
+export const CAMPUS_BUILDINGS: Record<CampusId, CampusBuildings> = {
+  SGW: {
+    id: 'SGW',
+    name: 'SGW Campus',
+    region: {
+      latitude: 45.4973,
+      longitude: -73.5789,
+      latitudeDelta: 0.01,
+      longitudeDelta: 0.01,
+    },
+    buildings: [
+      {
+        id: 'hall',
+        name: 'Henry F. Hall Building',
+        code: 'H',
+        description: 'Central building housing classrooms, offices, and student services.',
+      },
+      {
+        id: 'molson',
+        name: 'John Molson Building',
+        code: 'MB',
+        description: 'Home to the John Molson School of Business.',
+      },
+      {
+        id: 'ev',
+        name: 'Engineering, Computer Science and Visual Arts Integrated Complex',
+        code: 'EV',
+        description: 'Engineering, Computer Science and Visual Arts facilities.',
+      },
+      {
+        id: 'mcconnell',
+        name: 'J.W. McConnell Building',
+        code: 'LB',
+        description: 'Library and learning commons.',
+      },
+    ],
+  },
+  Loyola: {
+    id: 'Loyola',
+    name: 'Loyola Campus',
+    region: {
+      latitude: 45.4582,
+      longitude: -73.6405,
+      latitudeDelta: 0.01,
+      longitudeDelta: 0.01,
+    },
+    buildings: [
+      {
+        id: 'hingston',
+        name: 'Hingston Hall',
+        code: 'HA, HB, HC',
+        description: 'Multi-wing building with HA, HB, and HC wings.',
+      },
+      {
+        id: 'vanier',
+        name: 'Vanier Library Building',
+        code: 'VL',
+        description: 'Loyola campus library and study spaces.',
+      },
+      {
+        id: 'renaud',
+        name: 'Richard J. Renaud Science Complex',
+        code: 'SP',
+        description: 'Science facilities and labs.',
+      },
+      {
+        id: 'cj',
+        name: 'Communication Studies and Journalism Building',
+        code: 'CJ',
+        description: 'Department of Communication Studies and Journalism.',
+      },
+    ],
+  },
+};
+
+export const CAMPUS_IDS: CampusId[] = ['SGW', 'Loyola'];

--- a/mobile-app/constants/theme.ts
+++ b/mobile-app/constants/theme.ts
@@ -8,6 +8,10 @@ import { Platform } from 'react-native';
 const tintColorLight = '#0a7ea4';
 const tintColorDark = '#fff';
 
+/** Concordia University brand red - use for primary actions and accents */
+export const ConcordiaRed = '#912338';
+export const ConcordiaRedMuted = 'rgba(145, 35, 56, 0.12)';
+
 export const Colors = {
   light: {
     text: '#11181C',

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -2398,9 +2398,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
@@ -13808,9 +13808,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
- I added a footer which include the 4 main buildings for each campus (SGW and LOY)

For the Loyola Campus the 4 main buildings are:
- Hingston Hall (wing HA, wing HB, wing HC)
- Vanier Library Building (VL)
- Richard J. Renaud Science Complex (SP)
- Communication Studies and Journalism Building (CJ) 

For the SGW Campus the 4 main buildings are:
- Henry F. Hall Building (H)
- John Molson Building (MB)
- Engineering, Computer Science and Visual Arts Integrated Complex (EV)
- J.W. McConnell Building (LB)

NOTE: In order to switch between campuses. I had to implement the toggle for each campus. However this seems to be assigned to user_story 1.3