### PR TITLE
added a guard against undefined map coordinate on iOS tap event

### DIFF
--- a/mobile-app/components/MapScreen.tsx
+++ b/mobile-app/components/MapScreen.tsx
@@ -289,8 +289,10 @@ export default function MapScreen() {
                 showsCompass={false}
                 showsMyLocationButton={false}
                 onPress={(e) => {
-                    const { coordinate } = e.nativeEvent;
-                    handleMapCoordinatePress(coordinate);
+                    const coordinate = e.nativeEvent?.coordinate;
+                    if (coordinate?.latitude != null && coordinate?.longitude != null) {
+                        handleMapCoordinatePress(coordinate);
+                    }
                 }}
             >
                 {tapMarkerCoordinate && (


### PR DESCRIPTION
This pull request introduces a small improvement to the `MapScreen` component. The change adds a safety check to ensure that the map coordinate is valid before calling the handler function, which helps prevent potential runtime errors.

* Added null checks for `latitude` and `longitude` in the `onPress` event handler to ensure only valid coordinates are processed.