### PR TITLE
[PR] Implement outdoor POI search functionality and map integration (ES-5)

### DIFF
--- a/mobile-app/__tests__/MapScreen.outdoorPOI.test.tsx
+++ b/mobile-app/__tests__/MapScreen.outdoorPOI.test.tsx
@@ -1,0 +1,453 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import MapScreen from '../components/MapScreen';
+
+// ---------------------------------------------------------------------------
+// Common mocks (same pattern as MapScreen.indoorCategoryFilters.test.tsx)
+// ---------------------------------------------------------------------------
+
+const mockAnimateToRegion = jest.fn();
+
+jest.mock('react-native-maps', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const MockMapView = React.forwardRef((props: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({
+      animateToRegion: mockAnimateToRegion,
+    }));
+    return React.createElement(View, { ...props, testID: props.testID || 'map-view' });
+  });
+  return {
+    __esModule: true,
+    default: MockMapView,
+    Marker: (props: any) => React.createElement(View, { ...props }),
+    Polygon: (props: any) => React.createElement(View, { ...props }),
+    Polyline: (props: any) => React.createElement(View, { ...props }),
+  };
+});
+
+jest.mock('tamagui', () => ({
+  useTheme: () => ({
+    cred: { get: () => '#912338', val: '#912338' },
+    colourBlind1: { val: '#B3D4FF' },
+    colourBlind2: { val: '#FF8800' },
+  }),
+}));
+
+jest.mock('../context/settings', () => ({
+  useSettings: () => ({ colourBlindMode: false, simulatedNow: null }),
+}));
+
+jest.mock('expo-location');
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: 'Light' },
+}));
+
+jest.mock('@expo/vector-icons/MaterialIcons', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: (props: any) =>
+      React.createElement(View, { ...props, testID: props.testID || 'icon' }),
+  };
+});
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    MaterialIcons: (props: any) =>
+      React.createElement(View, { ...props, testID: props.testID || 'icon' }),
+  };
+});
+
+const mockBuildings = [
+  {
+    id: '1',
+    name: 'Hall Building',
+    address: '1455 De Maisonneuve',
+    code: 'H',
+    polygon: [
+      { latitude: 45.497, longitude: -73.579 },
+      { latitude: 45.497, longitude: -73.578 },
+      { latitude: 45.496, longitude: -73.578 },
+      { latitude: 45.496, longitude: -73.579 },
+    ],
+  },
+];
+
+jest.mock('../hooks/useCampusContext', () => ({
+  useCampusContext: () => ({
+    activeCampus: 'sgw',
+    buildings: mockBuildings,
+    sgwBuildings: mockBuildings,
+    loyolaBuildings: [],
+    handleSelectCampus: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/useSelectedBuilding', () => ({
+  useSelectedBuilding: () => ({
+    selectedBuildingId: null,
+    remoteBuilding: null,
+    isLoading: false,
+    errorMessage: null,
+    handleSelectBuilding: jest.fn(),
+    handleCloseCard: jest.fn(),
+  }),
+}));
+
+const mockSetSearchQuery = jest.fn();
+const mockSetIsSearchFocused = jest.fn();
+jest.mock('../hooks/useSearch', () => ({
+  useSearch: () => ({
+    searchQuery: '',
+    setSearchQuery: mockSetSearchQuery,
+    isSearchFocused: false,
+    setIsSearchFocused: mockSetIsSearchFocused,
+    searchInputRef: { current: { blur: jest.fn() } },
+    searchResults: [],
+    handleSearchSubmit: jest.fn(),
+    handleSelectSearchResult: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/useUserLocation', () => ({
+  useUserLocation: () => ({
+    isLocating: false,
+    goToUserLocation: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/useMapUI', () => ({
+  useMapUI: () => ({
+    isMenuOpen: false,
+    setIsMenuOpen: jest.fn(),
+    isQuickPickOpen: false,
+    quickPickContentHeight: 0,
+    setQuickPickContentHeight: jest.fn(),
+    quickPickVisibleHeight: 0,
+    quickPickMaxHeight: 300,
+    handleToggleQuickPick: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/usePublicCalendar', () => {
+  const actual = jest.requireActual('../hooks/usePublicCalendar');
+  return {
+    ...actual,
+    usePublicCalendar: () => ({
+      connectCalendar: jest.fn(),
+      disconnect: jest.fn(),
+      refreshEvents: jest.fn(),
+      isConnected: true,
+      events: [],
+      loading: false,
+      error: null,
+    }),
+  };
+});
+
+const mockOpenNavigationForCoordinate = jest.fn();
+jest.mock('../hooks/useNavigationBetweenBuildings', () => ({
+  useNavigationBetweenBuildings: () => ({
+    isNavigationOpen: false,
+    navigationStart: '',
+    navigationDestination: '',
+    navigationOrigin: null,
+    routeSummary: null,
+    modeDurations: {},
+    isRouteLoading: false,
+    directionsError: null,
+    isGetDirectionsDisabled: false,
+    setNavigationActiveField: jest.fn(),
+    openNavigationForBuilding: jest.fn(),
+    openNavigationForResolvedDestination: jest.fn(),
+    openNavigationForCoordinate: mockOpenNavigationForCoordinate,
+    openIndoorOnlyNavigation: jest.fn(),
+    handleMapBuildingPress: jest.fn(),
+    handleMapCoordinatePress: jest.fn(),
+    handleSearchSelect: jest.fn(),
+    setStartToCurrentLocation: jest.fn(),
+    setStartToCurrentLocationBuilding: jest.fn(),
+    closeNavigation: jest.fn(),
+    clearTapMarker: jest.fn(),
+    tapMarkerCoordinate: null,
+    selectedTransportMode: 'driving',
+    setSelectedTransportMode: jest.fn(),
+    setSelectedWalkingRouteVariant: jest.fn(),
+    walkingRouteComparison: null,
+    routePolyline: [],
+    routeRegion: null,
+    navigationSteps: [],
+    isShuttleRoute: false,
+    isShuttleLoading: false,
+    shuttleInfo: null,
+    isWeekend: false,
+    lateTransportModes: [],
+    routeSegments: [],
+    isIndoorOnlyRoute: false,
+    isDestinationLocked: false,
+    rerouteFromLocation: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/useIndoorNavigation', () => ({
+  useIndoorNavigation: () => ({
+    isIndoorActive: false,
+    activeBuildingCode: null,
+    activateBuilding: jest.fn(),
+    selectRoom: jest.fn(),
+    setActiveLevel: jest.fn(),
+    navigateToRoom: jest.fn(),
+    navigateToRoomAccessible: jest.fn(),
+    deactivate: jest.fn(),
+    indoorRoute: null,
+    activeLevelFeatures: [],
+    activeLevel: null,
+    destinationRoom: null,
+    selectedRoom: null,
+    levels: [],
+    error: null,
+    findNearest: jest.fn(),
+    rerouteCurrent: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/useIndoorRoomPicker', () => ({
+  useIndoorRoomPicker: () => ({
+    indoorRoomOptions: [],
+    handleIndoorRoomSelect: jest.fn(),
+  }),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('../tamagui.config', () => ({}));
+
+jest.mock('../data/buildingPolygons', () => ({
+  BUILDING_POLYGONS: {
+    H: {
+      name: 'Hall Building',
+      street: 'De Maisonneuve',
+      housenumber: '1455',
+      polygon: [
+        { latitude: 45.497, longitude: -73.579 },
+        { latitude: 45.497, longitude: -73.578 },
+        { latitude: 45.496, longitude: -73.578 },
+        { latitude: 45.496, longitude: -73.579 },
+      ],
+    },
+  },
+}));
+
+jest.mock('../data/buildingPolygonsLoyola', () => ({
+  LOYOLA_BUILDING_POLYGONS: {},
+}));
+
+jest.mock('../data/building-addresses', () => ({
+  BUILDING_ADDRESSES: [{ code: 'H', name: 'Hall Building', address: '1455 De Maisonneuve' }],
+}));
+
+// Stub heavy components we're not testing
+jest.mock('../components/CampusSwitch', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View, { testID: 'campus-switch' });
+});
+
+jest.mock('../components/NavigationScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return (props: any) =>
+    props.visible ? React.createElement(View, { testID: 'navigation-screen' }) : null;
+});
+
+jest.mock('../components/RoutePreviewScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return (props: any) =>
+    props.visible ? React.createElement(View, { testID: 'route-preview-screen' }) : null;
+});
+
+jest.mock('../components/DirectionsModeScreen', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return (props: any) =>
+    props.visible ? React.createElement(View, { testID: 'directions-mode-screen' }) : null;
+});
+
+jest.mock('../components/QuickPickPanel', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View, { testID: 'quick-pick-panel' });
+});
+
+jest.mock('../components/MapMenu', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View, { testID: 'map-menu' });
+});
+
+jest.mock('../components/CalendarModal', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View, { testID: 'calendar-modal' });
+});
+
+jest.mock('../components/NextClassPanel', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return ({ children }: any) =>
+    React.createElement(View, { testID: 'next-class-panel' }, children?.(jest.fn(), jest.fn()));
+});
+
+jest.mock('../components/ClassesCalendarRequired', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View, { testID: 'classes-calendar-required' });
+});
+
+jest.mock('../components/indoor/IndoorMapOverlay', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View, { testID: 'indoor-overlay' });
+});
+
+jest.mock('../components/indoor/FloorSelector', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View);
+});
+
+jest.mock('../components/indoor/RoomInfoBubble', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View);
+});
+
+jest.mock('../components/indoor/PoiInfoBubble', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View);
+});
+
+jest.mock('../components/indoor/IndoorStartPromptModal', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return () => React.createElement(View);
+});
+
+// ---------------------------------------------------------------------------
+// Outdoor POI mock
+// ---------------------------------------------------------------------------
+
+const testPOI = {
+  id: 'place123',
+  name: 'Great Cafe',
+  address: '100 Test St',
+  coordinate: { latitude: 45.498, longitude: -73.579 },
+  category: 'cafe',
+  rating: 4.5,
+  openNow: true,
+};
+
+const mockSelectPOI = jest.fn();
+const mockSelectPOIFromMap = jest.fn();
+const mockClearSelectedPOI = jest.fn();
+let mockOutdoorPOIState = {
+  outdoorPOIResults: [] as any[],
+  selectedOutdoorPOI: null as any,
+  isOutdoorPOILoading: false,
+  selectPOI: mockSelectPOI,
+  selectPOIFromMap: mockSelectPOIFromMap,
+  clearSelectedPOI: mockClearSelectedPOI,
+};
+
+jest.mock('../hooks/useOutdoorPOI', () => ({
+  useOutdoorPOI: () => mockOutdoorPOIState,
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MapScreen – Outdoor POI integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOutdoorPOIState = {
+      outdoorPOIResults: [],
+      selectedOutdoorPOI: null,
+      isOutdoorPOILoading: false,
+      selectPOI: mockSelectPOI,
+      selectPOIFromMap: mockSelectPOIFromMap,
+      clearSelectedPOI: mockClearSelectedPOI,
+    };
+  });
+
+  it('renders MapScreen without outdoor POI markers when no results', () => {
+    const { getByTestId, queryByTestId } = render(<MapScreen />);
+    expect(getByTestId('campus-map')).toBeTruthy();
+    expect(queryByTestId('outdoor-poi-marker-place123')).toBeNull();
+  });
+
+  it('renders outdoor POI markers when results are present', () => {
+    mockOutdoorPOIState.outdoorPOIResults = [testPOI];
+    const { getByTestId } = render(<MapScreen />);
+    expect(getByTestId('outdoor-poi-marker-place123')).toBeTruthy();
+  });
+
+  it('shows OutdoorPOIInfoCard when a POI is selected', () => {
+    mockOutdoorPOIState.selectedOutdoorPOI = testPOI;
+    const { getByTestId } = render(<MapScreen />);
+    expect(getByTestId('poi-name')).toBeTruthy();
+    expect(getByTestId('poi-name').props.children).toBe('Great Cafe');
+  });
+
+  it('does not show OutdoorPOIInfoCard when no POI is selected', () => {
+    mockOutdoorPOIState.selectedOutdoorPOI = null;
+    const { queryByTestId } = render(<MapScreen />);
+    expect(queryByTestId('poi-name')).toBeNull();
+  });
+
+  it('calls clearSelectedPOI when close button is pressed on the info card', () => {
+    mockOutdoorPOIState.selectedOutdoorPOI = testPOI;
+    const { getByTestId } = render(<MapScreen />);
+    fireEvent.press(getByTestId('poi-close-button'));
+    expect(mockClearSelectedPOI).toHaveBeenCalled();
+  });
+
+  it('calls openNavigationForCoordinate when Directions is pressed on the POI card', () => {
+    mockOutdoorPOIState.selectedOutdoorPOI = testPOI;
+    const { getByText } = render(<MapScreen />);
+    fireEvent.press(getByText('Directions'));
+    expect(mockOpenNavigationForCoordinate).toHaveBeenCalledWith('Great Cafe', testPOI.coordinate);
+    expect(mockClearSelectedPOI).toHaveBeenCalled();
+  });
+
+  it('selects a POI when a Google Maps built-in POI is tapped via onPoiClick', () => {
+    const { getByTestId } = render(<MapScreen />);
+    const map = getByTestId('campus-map');
+
+    fireEvent(map, 'onPoiClick', {
+      nativeEvent: {
+        placeId: 'gmap-poi-1',
+        name: 'K2 Bistro',
+        coordinate: { latitude: 45.496, longitude: -73.577 },
+      },
+    });
+
+    expect(mockSelectPOIFromMap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'gmap-poi-1',
+        name: 'K2 Bistro',
+        coordinate: { latitude: 45.496, longitude: -73.577 },
+        category: 'place',
+      }),
+    );
+  });
+});

--- a/mobile-app/__tests__/OutdoorPOIInfoCard.test.tsx
+++ b/mobile-app/__tests__/OutdoorPOIInfoCard.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import OutdoorPOIInfoCard from '../components/OutdoorPOIInfoCard';
+import type { OutdoorPOI } from '../services/outdoorPOIService';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('tamagui', () => ({
+  useTheme: () => ({
+    cred: { val: '#b21b2c' },
+    colourBlind1: { val: '#B3D4FF' },
+    colourBlind2: { val: '#FF8800' },
+  }),
+}));
+
+jest.mock('@expo/vector-icons/MaterialIcons', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: (props: any) =>
+      React.createElement(View, { ...props, testID: props.testID || 'icon' }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makePOI = (overrides?: Partial<OutdoorPOI>): OutdoorPOI => ({
+  id: 'p1',
+  name: 'Test Cafe',
+  address: '123 Main St',
+  coordinate: { latitude: 45.497, longitude: -73.578 },
+  category: 'cafe',
+  rating: 4.3,
+  openNow: true,
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OutdoorPOIInfoCard', () => {
+  it('renders null when poi is null', () => {
+    const { toJSON } = render(
+      <OutdoorPOIInfoCard poi={null} onClose={jest.fn()} isColorBlind={false} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders POI name, address, and category', () => {
+    const poi = makePOI();
+    const { getByTestId } = render(
+      <OutdoorPOIInfoCard poi={poi} onClose={jest.fn()} isColorBlind={false} />,
+    );
+
+    expect(getByTestId('poi-name').props.children).toBe('Test Cafe');
+    expect(getByTestId('poi-address').props.children).toBe('123 Main St');
+    expect(getByTestId('poi-category').props.children).toBe('cafe');
+  });
+
+  it('displays "Address unavailable" when address is empty', () => {
+    const poi = makePOI({ address: '' });
+    const { getByTestId } = render(
+      <OutdoorPOIInfoCard poi={poi} onClose={jest.fn()} isColorBlind={false} />,
+    );
+
+    expect(getByTestId('poi-address').props.children).toBe('Address unavailable');
+  });
+
+  it('renders rating when available', () => {
+    const poi = makePOI({ rating: 4.3 });
+    const { getByTestId } = render(
+      <OutdoorPOIInfoCard poi={poi} onClose={jest.fn()} isColorBlind={false} />,
+    );
+
+    expect(getByTestId('poi-rating').props.children).toBe('4.3');
+  });
+
+  it('does not render rating when undefined', () => {
+    const poi = makePOI({ rating: undefined });
+    const { queryByTestId } = render(
+      <OutdoorPOIInfoCard poi={poi} onClose={jest.fn()} isColorBlind={false} />,
+    );
+
+    expect(queryByTestId('poi-rating')).toBeNull();
+  });
+
+  it('shows open status text', () => {
+    const poiOpen = makePOI({ openNow: true });
+    const { getByTestId } = render(
+      <OutdoorPOIInfoCard poi={poiOpen} onClose={jest.fn()} isColorBlind={false} />,
+    );
+    expect(getByTestId('poi-open-status').props.children).toBe('Open now');
+  });
+
+  it('shows closed status text', () => {
+    const poiClosed = makePOI({ openNow: false });
+    const { getByTestId } = render(
+      <OutdoorPOIInfoCard poi={poiClosed} onClose={jest.fn()} isColorBlind={false} />,
+    );
+    expect(getByTestId('poi-open-status').props.children).toBe('Closed');
+  });
+
+  it('does not render open status when undefined', () => {
+    const poi = makePOI({ openNow: undefined });
+    const { queryByTestId } = render(
+      <OutdoorPOIInfoCard poi={poi} onClose={jest.fn()} isColorBlind={false} />,
+    );
+    expect(queryByTestId('poi-open-status')).toBeNull();
+  });
+
+  it('formats category with underscores as spaces', () => {
+    const poi = makePOI({ category: 'gas_station' });
+    const { getByTestId } = render(
+      <OutdoorPOIInfoCard poi={poi} onClose={jest.fn()} isColorBlind={false} />,
+    );
+    expect(getByTestId('poi-category').props.children).toBe('gas station');
+  });
+
+  it('calls onClose when close button is pressed', () => {
+    const onClose = jest.fn();
+    const poi = makePOI();
+    const { getByTestId } = render(
+      <OutdoorPOIInfoCard poi={poi} onClose={onClose} isColorBlind={false} />,
+    );
+
+    fireEvent.press(getByTestId('poi-close-button'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDirections when Directions button is pressed', () => {
+    const onDirections = jest.fn();
+    const poi = makePOI();
+    const { getByText } = render(
+      <OutdoorPOIInfoCard
+        poi={poi}
+        onClose={jest.fn()}
+        onDirections={onDirections}
+        isColorBlind={false}
+      />,
+    );
+
+    fireEvent.press(getByText('Directions'));
+    expect(onDirections).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders with colourBlind styles when isColorBlind is true', () => {
+    const poi = makePOI();
+    const { getByTestId } = render(
+      <OutdoorPOIInfoCard poi={poi} onClose={jest.fn()} isColorBlind={true} />,
+    );
+
+    expect(getByTestId('poi-name')).toBeTruthy();
+  });
+});

--- a/mobile-app/__tests__/outdoorPOIService.test.ts
+++ b/mobile-app/__tests__/outdoorPOIService.test.ts
@@ -13,9 +13,23 @@ import {
 jest.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
 
 const MOCK_KEY = 'test-api-key';
+let originalIosKey: string | undefined;
+let originalAndroidKey: string | undefined;
+
 beforeAll(() => {
+  originalIosKey = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS;
+  originalAndroidKey = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_ANDROID;
+});
+
+beforeEach(() => {
   process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = MOCK_KEY;
   process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_ANDROID = MOCK_KEY;
+});
+
+afterEach(() => {
+  process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = originalIosKey;
+  process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_ANDROID = originalAndroidKey;
+  jest.restoreAllMocks();
 });
 
 const SGW_CENTER = { latitude: 45.4973, longitude: -73.5789 };

--- a/mobile-app/__tests__/outdoorPOIService.test.ts
+++ b/mobile-app/__tests__/outdoorPOIService.test.ts
@@ -330,12 +330,10 @@ describe('fetchPlaceDetails', () => {
   });
 
   it('returns empty address when API key is empty', async () => {
-    const original = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS;
-    process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = '';
-    const details = await fetchPlaceDetails('ChIJ123');
-    expect(details.address).toBe('');
-    process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = original;
-  });
+  process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = '';
+  const details = await fetchPlaceDetails('ChIJ123');
+  expect(details.address).toBe('');
+});
 
   it('constructs the correct URL with place_id and fields', async () => {
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({

--- a/mobile-app/__tests__/outdoorPOIService.test.ts
+++ b/mobile-app/__tests__/outdoorPOIService.test.ts
@@ -247,14 +247,11 @@ describe('fetchNearbyPOIs', () => {
     const pois = await fetchNearbyPOIs('restaurant', center, 5000);
     expect(pois).toEqual([]);
   });
-
-  it('returns empty array when API key is empty', async () => {
-    const original = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS;
-    process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = '';
-    const pois = await fetchNearbyPOIs('restaurant', center, 5000);
-    expect(pois).toEqual([]);
-    process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = original;
-  });
+it('returns empty array when API key is empty', async () => {
+  process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = '';
+  const pois = await fetchNearbyPOIs('restaurant', center, 5000);
+  expect(pois).toEqual([]);
+});
 
   it('constructs the correct URL', async () => {
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({

--- a/mobile-app/__tests__/outdoorPOIService.test.ts
+++ b/mobile-app/__tests__/outdoorPOIService.test.ts
@@ -1,0 +1,367 @@
+import {
+  isSupportedPOICategory,
+  fetchNearbyPOIs,
+  fetchPlaceDetails,
+  getCampusCenterForPOI,
+  SUPPORTED_CATEGORIES,
+} from '../services/outdoorPOIService';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+
+const MOCK_KEY = 'test-api-key';
+beforeAll(() => {
+  process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = MOCK_KEY;
+  process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_ANDROID = MOCK_KEY;
+});
+
+const SGW_CENTER = { latitude: 45.4973, longitude: -73.5789 };
+const LOYOLA_CENTER = { latitude: 45.4581, longitude: -73.6402 };
+
+// ---------------------------------------------------------------------------
+// isSupportedPOICategory
+// ---------------------------------------------------------------------------
+
+describe('isSupportedPOICategory', () => {
+  it('resolves "restaurant" to the restaurant type', () => {
+    expect(isSupportedPOICategory('restaurant')).toBe('restaurant');
+  });
+
+  it('resolves "restaurants" (plural) to the restaurant type', () => {
+    expect(isSupportedPOICategory('restaurants')).toBe('restaurant');
+  });
+
+  it('resolves "food" to the restaurant type', () => {
+    expect(isSupportedPOICategory('food')).toBe('restaurant');
+  });
+
+  it('resolves "pharmacy" to the pharmacy type', () => {
+    expect(isSupportedPOICategory('pharmacy')).toBe('pharmacy');
+  });
+
+  it('resolves "drugstore" to the pharmacy type', () => {
+    expect(isSupportedPOICategory('drugstore')).toBe('pharmacy');
+  });
+
+  it('resolves "cafe" to the cafe type', () => {
+    expect(isSupportedPOICategory('cafe')).toBe('cafe');
+  });
+
+  it('resolves "coffee" to the cafe type', () => {
+    expect(isSupportedPOICategory('coffee')).toBe('cafe');
+  });
+
+  it('resolves "coffeeshop" to the cafe type', () => {
+    expect(isSupportedPOICategory('coffeeshop')).toBe('cafe');
+  });
+
+  it('resolves "gym" to the gym type', () => {
+    expect(isSupportedPOICategory('gym')).toBe('gym');
+  });
+
+  it('resolves "bank" to the bank type', () => {
+    expect(isSupportedPOICategory('bank')).toBe('bank');
+  });
+
+  it('resolves "supermarket" to the supermarket type', () => {
+    expect(isSupportedPOICategory('supermarket')).toBe('supermarket');
+  });
+
+  it('resolves "grocery" to the supermarket type', () => {
+    expect(isSupportedPOICategory('grocery')).toBe('supermarket');
+  });
+
+  it('resolves "bar" to the bar type', () => {
+    expect(isSupportedPOICategory('bar')).toBe('bar');
+  });
+
+  it('resolves "hospital" to the hospital type', () => {
+    expect(isSupportedPOICategory('hospital')).toBe('hospital');
+  });
+
+  it('resolves "parking" to the parking type', () => {
+    expect(isSupportedPOICategory('parking')).toBe('parking');
+  });
+
+  it('resolves "gas" to the gas_station type', () => {
+    expect(isSupportedPOICategory('gas')).toBe('gas_station');
+  });
+
+  it('resolves "hotel" to the hotel type', () => {
+    expect(isSupportedPOICategory('hotel')).toBe('hotel');
+  });
+
+  it('is case-insensitive', () => {
+    expect(isSupportedPOICategory('RESTAURANT')).toBe('restaurant');
+    expect(isSupportedPOICategory('Cafe')).toBe('cafe');
+    expect(isSupportedPOICategory('  Pharmacy  ')).toBe('pharmacy');
+  });
+
+  it('returns null for unsupported queries', () => {
+    expect(isSupportedPOICategory('bixi')).toBeNull();
+    expect(isSupportedPOICategory('hall building')).toBeNull();
+    expect(isSupportedPOICategory('')).toBeNull();
+  });
+
+  it('SUPPORTED_CATEGORIES contains expected values', () => {
+    expect(SUPPORTED_CATEGORIES).toContain('restaurant');
+    expect(SUPPORTED_CATEGORIES).toContain('cafe');
+    expect(SUPPORTED_CATEGORIES).toContain('pharmacy');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchNearbyPOIs
+// ---------------------------------------------------------------------------
+
+describe('fetchNearbyPOIs', () => {
+  const center = SGW_CENTER;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('preserves API distance order and maps fields correctly', async () => {
+    const mockResults = [
+      {
+        place_id: 'p2',
+        name: 'Nearby Cafe',
+        vicinity: '1 Close St',
+        geometry: { location: { lat: 45.498, lng: -73.579 } },
+        rating: 4.5,
+        opening_hours: { open_now: false },
+      },
+      {
+        place_id: 'p1',
+        name: 'Faraway Cafe',
+        vicinity: '100 Far St',
+        geometry: { location: { lat: 45.51, lng: -73.57 } },
+        rating: 4.2,
+        opening_hours: { open_now: true },
+      },
+    ];
+
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'OK', results: mockResults }),
+    } as Response);
+
+    const pois = await fetchNearbyPOIs('cafe', center, 5000);
+
+    expect(pois).toHaveLength(2);
+    expect(pois[0].name).toBe('Nearby Cafe');
+    expect(pois[1].name).toBe('Faraway Cafe');
+    expect(pois[0].id).toBe('p2');
+    expect(pois[0].category).toBe('cafe');
+    expect(pois[0].rating).toBe(4.5);
+    expect(pois[0].openNow).toBe(false);
+    expect(pois[1].openNow).toBe(true);
+  });
+
+  it('returns all results within radius (no artificial cap)', async () => {
+    const mockResults = Array.from({ length: 15 }, (_, i) => ({
+      place_id: `p${i}`,
+      name: `Place ${i}`,
+      vicinity: `${i} St`,
+      geometry: { location: { lat: 45.497 + i * 0.0001, lng: -73.578 } },
+    }));
+
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'OK', results: mockResults }),
+    } as Response);
+
+    const pois = await fetchNearbyPOIs('restaurant', center, 5000);
+    expect(pois).toHaveLength(15);
+  });
+
+  it('filters out POIs beyond the radius', async () => {
+    const mockResults = [
+      {
+        place_id: 'near',
+        name: 'Near Place',
+        vicinity: '1 Close St',
+        geometry: { location: { lat: 45.498, lng: -73.579 } },
+      },
+      {
+        place_id: 'far',
+        name: 'Far Place',
+        vicinity: '100 Far St',
+        geometry: { location: { lat: 46.0, lng: -73.0 } },
+      },
+    ];
+
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'OK', results: mockResults }),
+    } as Response);
+
+    const pois = await fetchNearbyPOIs('restaurant', center, 5000);
+    expect(pois).toHaveLength(1);
+    expect(pois[0].name).toBe('Near Place');
+  });
+
+  it('returns empty array on ZERO_RESULTS', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'ZERO_RESULTS', results: [] }),
+    } as Response);
+
+    const pois = await fetchNearbyPOIs('restaurant', center, 5000);
+    expect(pois).toEqual([]);
+  });
+
+  it('returns empty array when response is not ok', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    const pois = await fetchNearbyPOIs('restaurant', center, 5000);
+    expect(pois).toEqual([]);
+  });
+
+  it('returns empty array on API error status', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'REQUEST_DENIED', results: [] }),
+    } as Response);
+
+    const pois = await fetchNearbyPOIs('restaurant', center, 5000);
+    expect(pois).toEqual([]);
+  });
+
+  it('returns empty array when API key is empty', async () => {
+    const original = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS;
+    process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = '';
+    const pois = await fetchNearbyPOIs('restaurant', center, 5000);
+    expect(pois).toEqual([]);
+    process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = original;
+  });
+
+  it('constructs the correct URL', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'OK', results: [] }),
+    } as Response);
+
+    await fetchNearbyPOIs('pharmacy', center, 5000);
+
+    const calledUrl = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('type=pharmacy');
+    expect(calledUrl).toContain(`location=${center.latitude},${center.longitude}`);
+    expect(calledUrl).toContain('rankby=distance');
+    expect(calledUrl).toContain(`key=${MOCK_KEY}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPlaceDetails
+// ---------------------------------------------------------------------------
+
+describe('fetchPlaceDetails', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns address, rating, and openNow from the API', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 'OK',
+        result: {
+          formatted_address: '123 Main St, Montreal, QC',
+          rating: 4.3,
+          opening_hours: { open_now: true },
+        },
+      }),
+    } as Response);
+
+    const details = await fetchPlaceDetails('ChIJ123');
+    expect(details.address).toBe('123 Main St, Montreal, QC');
+    expect(details.rating).toBe(4.3);
+    expect(details.openNow).toBe(true);
+  });
+
+  it('returns empty address when API response is not OK', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'NOT_FOUND' }),
+    } as Response);
+
+    const details = await fetchPlaceDetails('bad-id');
+    expect(details.address).toBe('');
+  });
+
+  it('returns empty address when fetch fails', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    const details = await fetchPlaceDetails('ChIJ123');
+    expect(details.address).toBe('');
+  });
+
+  it('returns empty address when API key is empty', async () => {
+    const original = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS;
+    process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = '';
+    const details = await fetchPlaceDetails('ChIJ123');
+    expect(details.address).toBe('');
+    process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS = original;
+  });
+
+  it('constructs the correct URL with place_id and fields', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'OK', result: { formatted_address: 'Abc' } }),
+    } as Response);
+
+    await fetchPlaceDetails('ChIJ_test');
+    const calledUrl = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('place_id=ChIJ_test');
+    expect(calledUrl).toContain('fields=formatted_address,rating,opening_hours');
+    expect(calledUrl).toContain(`key=${MOCK_KEY}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCampusCenterForPOI
+// ---------------------------------------------------------------------------
+
+describe('getCampusCenterForPOI', () => {
+  it('returns user location when user is on SGW campus', () => {
+    const userOnSGW = { latitude: 45.4965, longitude: -73.578 };
+    const result = getCampusCenterForPOI(userOnSGW, 'loyola');
+    expect(result).toEqual(userOnSGW);
+  });
+
+  it('returns user location when user is on Loyola campus', () => {
+    const userOnLoyola = { latitude: 45.458, longitude: -73.64 };
+    const result = getCampusCenterForPOI(userOnLoyola, 'sgw');
+    expect(result).toEqual(userOnLoyola);
+  });
+
+  it('returns SGW center when user is off-campus and active campus is sgw', () => {
+    const userOffCampus = { latitude: 45.52, longitude: -73.6 };
+    const result = getCampusCenterForPOI(userOffCampus, 'sgw');
+    expect(result).toEqual(SGW_CENTER);
+  });
+
+  it('returns Loyola center when user is off-campus and active campus is loyola', () => {
+    const userOffCampus = { latitude: 45.52, longitude: -73.6 };
+    const result = getCampusCenterForPOI(userOffCampus, 'loyola');
+    expect(result).toEqual(LOYOLA_CENTER);
+  });
+
+  it('returns SGW center when user location is null and active campus is sgw', () => {
+    expect(getCampusCenterForPOI(null, 'sgw')).toEqual(SGW_CENTER);
+  });
+
+  it('returns Loyola center when user location is null and active campus is loyola', () => {
+    expect(getCampusCenterForPOI(null, 'loyola')).toEqual(LOYOLA_CENTER);
+  });
+});

--- a/mobile-app/__tests__/outdoorPOIService.test.ts
+++ b/mobile-app/__tests__/outdoorPOIService.test.ts
@@ -256,6 +256,18 @@ describe('fetchNearbyPOIs', () => {
     expect(calledUrl).toContain('rankby=distance');
     expect(calledUrl).toContain(`key=${MOCK_KEY}`);
   });
+
+  it('passes AbortSignal to fetch when provided', async () => {
+    const signal = new AbortController().signal;
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 'OK', results: [] }),
+    } as Response);
+
+    await fetchNearbyPOIs('pharmacy', center, 5000, signal);
+
+    expect(fetchSpy).toHaveBeenCalledWith(expect.any(String), { signal });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/mobile-app/__tests__/useNavigationBetweenBuildings-Test.ts
+++ b/mobile-app/__tests__/useNavigationBetweenBuildings-Test.ts
@@ -2068,4 +2068,48 @@ describe('useNavigationBetweenBuildings', () => {
       expect(result.current.isIndoorOnlyRoute).toBe(false);
     });
   });
+
+  describe('openNavigationForCoordinate', () => {
+    it('sets destination label and coordinate, opens navigation', () => {
+      const { result } = renderNavHook();
+      const coord = { latitude: 45.501, longitude: -73.575 };
+
+      act(() => {
+        result.current.openNavigationForCoordinate('Great Cafe', coord);
+      });
+
+      expect(result.current.isNavigationOpen).toBe(true);
+      expect(result.current.navigationDestination).toBe('Great Cafe');
+      expect(result.current.navigationStart).toBe('Your location');
+      expect(result.current.tapMarkerCoordinate).toEqual(coord);
+    });
+
+    it('does not set isDestinationLocked', () => {
+      const { result } = renderNavHook();
+      const coord = { latitude: 45.501, longitude: -73.575 };
+
+      act(() => {
+        result.current.openNavigationForCoordinate('Test Place', coord);
+      });
+
+      expect(result.current.isDestinationLocked).toBe(false);
+    });
+
+    it('resets isIndoorOnlyRoute to false', () => {
+      const { result } = renderNavHook();
+
+      act(() => {
+        result.current.openIndoorOnlyNavigation('H-840', 'Hall Building');
+      });
+      expect(result.current.isIndoorOnlyRoute).toBe(true);
+
+      act(() => {
+        result.current.openNavigationForCoordinate('Pharmacy', {
+          latitude: 45.499,
+          longitude: -73.577,
+        });
+      });
+      expect(result.current.isIndoorOnlyRoute).toBe(false);
+    });
+  });
 });

--- a/mobile-app/__tests__/useOutdoorPOI.test.ts
+++ b/mobile-app/__tests__/useOutdoorPOI.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useOutdoorPOI } from '../hooks/useOutdoorPOI';
+import type { LatLng } from '../utils/mapUtils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -25,6 +26,10 @@ jest.mock('expo-location', () => ({
 
 const SGW_CENTER = { latitude: 45.4973, longitude: -73.5789 };
 let warnSpy: jest.SpiedFunction<typeof console.warn>;
+
+function expectAbortSignal(signal: unknown) {
+  expect(signal).toEqual(expect.objectContaining({ aborted: false }));
+}
 
 const makePOI = (id: string, name: string) => ({
   id,
@@ -84,7 +89,12 @@ describe('useOutdoorPOI', () => {
       expect(result.current.outdoorPOIResults).toEqual(pois);
     });
 
-    expect(mockFetchNearbyPOIs).toHaveBeenCalledWith('cafe', SGW_CENTER, 1000);
+    expect(mockFetchNearbyPOIs).toHaveBeenCalledWith(
+      'cafe',
+      SGW_CENTER,
+      1000,
+      expect.objectContaining({ aborted: false }),
+    );
     expect(mockGetCampusCenterForPOI).toHaveBeenCalledWith(null, 'sgw');
     expect(result.current.isOutdoorPOILoading).toBe(false);
   });
@@ -300,7 +310,12 @@ describe('useOutdoorPOI', () => {
     );
 
     await waitFor(() => {
-      expect(mockFetchNearbyPOIs).toHaveBeenCalledWith('cafe', userLocation, 1000);
+      expect(mockFetchNearbyPOIs).toHaveBeenCalledWith(
+        'cafe',
+        userLocation,
+        1000,
+        expect.objectContaining({ aborted: false }),
+      );
     });
     expect(mockGetCurrentPositionAsync).not.toHaveBeenCalled();
     expect(mockGetCampusCenterForPOI).not.toHaveBeenCalled();
@@ -324,7 +339,12 @@ describe('useOutdoorPOI', () => {
 
     await waitFor(() => {
       expect(mockGetCurrentPositionAsync).toHaveBeenCalled();
-      expect(mockFetchNearbyPOIs).toHaveBeenCalledWith('cafe', gpsLocation, 1000);
+      expect(mockFetchNearbyPOIs).toHaveBeenCalledWith(
+        'cafe',
+        gpsLocation,
+        1000,
+        expect.objectContaining({ aborted: false }),
+      );
     });
     expect(mockGetCampusCenterForPOI).not.toHaveBeenCalled();
   });
@@ -350,5 +370,55 @@ describe('useOutdoorPOI', () => {
       'useOutdoorPOI: failed to get current position for POI search',
       error,
     );
+  });
+
+  it('aborts the previous POI request when a new search starts', async () => {
+    const secondResults = [makePOI('p2', 'New Cafe')];
+    mockIsSupportedPOICategory.mockImplementation((query: string) => query);
+    mockGetCurrentPositionAsync.mockResolvedValue({
+      coords: { latitude: SGW_CENTER.latitude, longitude: SGW_CENTER.longitude },
+    });
+
+    mockFetchNearbyPOIs
+      .mockImplementationOnce(
+        (_type: string, _center: unknown, _radius: number, signal?: AbortSignal) =>
+          new Promise((_, reject) => {
+            signal?.addEventListener('abort', () => {
+              reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }));
+            });
+          }),
+      )
+      .mockResolvedValueOnce(secondResults);
+
+    const { result, rerender } = renderHook((props) => useOutdoorPOI(props), {
+      initialProps: {
+        debouncedQuery: 'cafe',
+        userLocation: null as LatLng | null,
+        activeCampus: 'sgw' as const,
+      },
+    });
+
+    await waitFor(() => {
+      expect(mockFetchNearbyPOIs).toHaveBeenCalledTimes(1);
+    });
+
+    const firstSignal = mockFetchNearbyPOIs.mock.calls[0][3];
+    expectAbortSignal(firstSignal);
+
+    rerender({
+      debouncedQuery: 'restaurant',
+      userLocation: null,
+      activeCampus: 'sgw' as const,
+    });
+
+    await waitFor(() => {
+      expect(mockFetchNearbyPOIs).toHaveBeenCalledTimes(2);
+    });
+
+    expect(firstSignal.aborted).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.outdoorPOIResults).toEqual(secondResults);
+    });
   });
 });

--- a/mobile-app/__tests__/useOutdoorPOI.test.ts
+++ b/mobile-app/__tests__/useOutdoorPOI.test.ts
@@ -1,0 +1,336 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useOutdoorPOI } from '../hooks/useOutdoorPOI';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockFetchNearbyPOIs = jest.fn();
+const mockIsSupportedPOICategory = jest.fn();
+const mockGetCampusCenterForPOI = jest.fn();
+const mockReverseGeocodeAsync = jest.fn();
+const mockGetCurrentPositionAsync = jest.fn();
+
+jest.mock('../services/outdoorPOIService', () => ({
+  isSupportedPOICategory: (...args: any[]) => mockIsSupportedPOICategory(...args),
+  fetchNearbyPOIs: (...args: any[]) => mockFetchNearbyPOIs(...args),
+  getCampusCenterForPOI: (...args: any[]) => mockGetCampusCenterForPOI(...args),
+}));
+
+jest.mock('expo-location', () => ({
+  reverseGeocodeAsync: (...args: any[]) => mockReverseGeocodeAsync(...args),
+  getCurrentPositionAsync: (...args: any[]) => mockGetCurrentPositionAsync(...args),
+  Accuracy: { Balanced: 3 },
+}));
+
+const SGW_CENTER = { latitude: 45.4973, longitude: -73.5789 };
+
+const makePOI = (id: string, name: string) => ({
+  id,
+  name,
+  address: `${name} St`,
+  coordinate: { latitude: 45.497, longitude: -73.578 },
+  category: 'restaurant',
+  rating: 4.0,
+  openNow: true,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useOutdoorPOI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCampusCenterForPOI.mockReturnValue(SGW_CENTER);
+  });
+
+  it('returns empty results when query is not a supported category', () => {
+    mockIsSupportedPOICategory.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: 'hall building',
+        userLocation: null,
+        activeCampus: 'sgw',
+      }),
+    );
+
+    expect(result.current.outdoorPOIResults).toEqual([]);
+    expect(result.current.isOutdoorPOILoading).toBe(false);
+    expect(mockFetchNearbyPOIs).not.toHaveBeenCalled();
+  });
+
+  it('fetches POIs when query matches a category', async () => {
+    const pois = [makePOI('p1', 'Cafe A'), makePOI('p2', 'Cafe B')];
+    mockIsSupportedPOICategory.mockReturnValue('cafe');
+    mockFetchNearbyPOIs.mockResolvedValue(pois);
+
+    const { result } = renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: 'cafe',
+        userLocation: null,
+        activeCampus: 'sgw',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.outdoorPOIResults).toEqual(pois);
+    });
+
+    expect(mockFetchNearbyPOIs).toHaveBeenCalledWith('cafe', SGW_CENTER, 1000);
+    expect(mockGetCampusCenterForPOI).toHaveBeenCalledWith(null, 'sgw');
+    expect(result.current.isOutdoorPOILoading).toBe(false);
+  });
+
+  it('clears results when query changes to non-category', async () => {
+    const pois = [makePOI('p1', 'Cafe A')];
+    mockIsSupportedPOICategory.mockReturnValue('cafe');
+    mockFetchNearbyPOIs.mockResolvedValue(pois);
+
+    const { result, rerender } = renderHook((props) => useOutdoorPOI(props), {
+      initialProps: {
+        debouncedQuery: 'cafe',
+        userLocation: null as any,
+        activeCampus: 'sgw' as const,
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.outdoorPOIResults).toHaveLength(1);
+    });
+
+    mockIsSupportedPOICategory.mockReturnValue(null);
+    rerender({
+      debouncedQuery: 'hall',
+      userLocation: null,
+      activeCampus: 'sgw' as const,
+    });
+
+    await waitFor(() => {
+      expect(result.current.outdoorPOIResults).toEqual([]);
+    });
+  });
+
+  it('handles fetch errors gracefully', async () => {
+    mockIsSupportedPOICategory.mockReturnValue('restaurant');
+    mockFetchNearbyPOIs.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: 'restaurant',
+        userLocation: null,
+        activeCampus: 'sgw',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isOutdoorPOILoading).toBe(false);
+    });
+
+    expect(result.current.outdoorPOIResults).toEqual([]);
+  });
+
+  it('selectPOI sets selectedOutdoorPOI', async () => {
+    mockIsSupportedPOICategory.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: '',
+        userLocation: null,
+        activeCampus: 'sgw',
+      }),
+    );
+
+    const poi = makePOI('p1', 'Test Cafe');
+    act(() => {
+      result.current.selectPOI(poi);
+    });
+
+    expect(result.current.selectedOutdoorPOI).toEqual(poi);
+  });
+
+  it('clearSelectedPOI clears selectedOutdoorPOI', async () => {
+    mockIsSupportedPOICategory.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: '',
+        userLocation: null,
+        activeCampus: 'sgw',
+      }),
+    );
+
+    const poi = makePOI('p1', 'Test Cafe');
+    act(() => {
+      result.current.selectPOI(poi);
+    });
+    expect(result.current.selectedOutdoorPOI).toEqual(poi);
+
+    act(() => {
+      result.current.clearSelectedPOI();
+    });
+    expect(result.current.selectedOutdoorPOI).toBeNull();
+  });
+
+  it('selectPOIFromMap resolves address via reverse geocoding', async () => {
+    mockIsSupportedPOICategory.mockReturnValue(null);
+    mockReverseGeocodeAsync.mockResolvedValue([
+      {
+        streetNumber: '456',
+        street: 'Fetched Ave',
+        city: 'Montreal',
+        region: 'QC',
+        formattedAddress: null,
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: '',
+        userLocation: null,
+        activeCampus: 'sgw',
+      }),
+    );
+
+    const basePOI = {
+      id: 'gmap-poi-1',
+      name: 'Map POI',
+      address: '',
+      coordinate: { latitude: 45.497, longitude: -73.578 },
+      category: 'place',
+    };
+
+    await act(async () => {
+      result.current.selectPOIFromMap(basePOI);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedOutdoorPOI?.address).toBe('456 Fetched Ave, Montreal, QC');
+    });
+
+    expect(mockReverseGeocodeAsync).toHaveBeenCalledWith(basePOI.coordinate);
+  });
+
+  it('selectPOIFromMap uses formattedAddress when available', async () => {
+    mockIsSupportedPOICategory.mockReturnValue(null);
+    mockReverseGeocodeAsync.mockResolvedValue([
+      { formattedAddress: '456 Fetched Ave, Montreal, QC H3G 1M8, Canada' },
+    ]);
+
+    const { result } = renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: '',
+        userLocation: null,
+        activeCampus: 'sgw',
+      }),
+    );
+
+    const basePOI = {
+      id: 'gmap-poi-fmt',
+      name: 'Formatted POI',
+      address: '',
+      coordinate: { latitude: 45.497, longitude: -73.578 },
+      category: 'place',
+    };
+
+    await act(async () => {
+      result.current.selectPOIFromMap(basePOI);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedOutdoorPOI?.address).toBe(
+        '456 Fetched Ave, Montreal, QC H3G 1M8, Canada',
+      );
+    });
+  });
+
+  it('selectPOIFromMap keeps base POI if reverse geocoding fails', async () => {
+    mockIsSupportedPOICategory.mockReturnValue(null);
+    mockReverseGeocodeAsync.mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: '',
+        userLocation: null,
+        activeCampus: 'sgw',
+      }),
+    );
+
+    const basePOI = {
+      id: 'gmap-poi-2',
+      name: 'Another POI',
+      address: '',
+      coordinate: { latitude: 45.497, longitude: -73.578 },
+      category: 'place',
+    };
+
+    await act(async () => {
+      result.current.selectPOIFromMap(basePOI);
+    });
+
+    expect(result.current.selectedOutdoorPOI?.name).toBe('Another POI');
+    expect(result.current.selectedOutdoorPOI?.address).toBe('');
+  });
+
+  it('uses cached user location as search center when available', async () => {
+    const userLocation = { latitude: 45.496, longitude: -73.578 };
+    mockIsSupportedPOICategory.mockReturnValue('cafe');
+    mockFetchNearbyPOIs.mockResolvedValue([]);
+
+    renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: 'cafe',
+        userLocation,
+        activeCampus: 'loyola',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockFetchNearbyPOIs).toHaveBeenCalledWith('cafe', userLocation, 1000);
+    });
+    expect(mockGetCurrentPositionAsync).not.toHaveBeenCalled();
+    expect(mockGetCampusCenterForPOI).not.toHaveBeenCalled();
+  });
+
+  it('requests GPS when cached location is null', async () => {
+    const gpsLocation = { latitude: 45.499, longitude: -73.577 };
+    mockIsSupportedPOICategory.mockReturnValue('cafe');
+    mockFetchNearbyPOIs.mockResolvedValue([]);
+    mockGetCurrentPositionAsync.mockResolvedValue({
+      coords: { latitude: gpsLocation.latitude, longitude: gpsLocation.longitude },
+    });
+
+    renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: 'cafe',
+        userLocation: null,
+        activeCampus: 'loyola',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetCurrentPositionAsync).toHaveBeenCalled();
+      expect(mockFetchNearbyPOIs).toHaveBeenCalledWith('cafe', gpsLocation, 1000);
+    });
+    expect(mockGetCampusCenterForPOI).not.toHaveBeenCalled();
+  });
+
+  it('falls back to campus center when GPS also fails', async () => {
+    mockIsSupportedPOICategory.mockReturnValue('cafe');
+    mockFetchNearbyPOIs.mockResolvedValue([]);
+    mockGetCurrentPositionAsync.mockRejectedValue(new Error('GPS denied'));
+
+    renderHook(() =>
+      useOutdoorPOI({
+        debouncedQuery: 'cafe',
+        userLocation: null,
+        activeCampus: 'loyola',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetCampusCenterForPOI).toHaveBeenCalledWith(null, 'loyola');
+    });
+  });
+});

--- a/mobile-app/__tests__/useOutdoorPOI.test.ts
+++ b/mobile-app/__tests__/useOutdoorPOI.test.ts
@@ -24,6 +24,7 @@ jest.mock('expo-location', () => ({
 }));
 
 const SGW_CENTER = { latitude: 45.4973, longitude: -73.5789 };
+let warnSpy: jest.SpiedFunction<typeof console.warn>;
 
 const makePOI = (id: string, name: string) => ({
   id,
@@ -42,7 +43,12 @@ const makePOI = (id: string, name: string) => ({
 describe('useOutdoorPOI', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     mockGetCampusCenterForPOI.mockReturnValue(SGW_CENTER);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
   });
 
   it('returns empty results when query is not a supported category', () => {
@@ -247,7 +253,8 @@ describe('useOutdoorPOI', () => {
 
   it('selectPOIFromMap keeps base POI if reverse geocoding fails', async () => {
     mockIsSupportedPOICategory.mockReturnValue(null);
-    mockReverseGeocodeAsync.mockRejectedValue(new Error('fail'));
+    const error = new Error('fail');
+    mockReverseGeocodeAsync.mockRejectedValue(error);
 
     const { result } = renderHook(() =>
       useOutdoorPOI({
@@ -271,6 +278,12 @@ describe('useOutdoorPOI', () => {
 
     expect(result.current.selectedOutdoorPOI?.name).toBe('Another POI');
     expect(result.current.selectedOutdoorPOI?.address).toBe('');
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        'useOutdoorPOI: reverse geocoding failed for selected POI',
+        error,
+      );
+    });
   });
 
   it('uses cached user location as search center when available', async () => {
@@ -319,7 +332,8 @@ describe('useOutdoorPOI', () => {
   it('falls back to campus center when GPS also fails', async () => {
     mockIsSupportedPOICategory.mockReturnValue('cafe');
     mockFetchNearbyPOIs.mockResolvedValue([]);
-    mockGetCurrentPositionAsync.mockRejectedValue(new Error('GPS denied'));
+    const error = new Error('GPS denied');
+    mockGetCurrentPositionAsync.mockRejectedValue(error);
 
     renderHook(() =>
       useOutdoorPOI({
@@ -332,5 +346,9 @@ describe('useOutdoorPOI', () => {
     await waitFor(() => {
       expect(mockGetCampusCenterForPOI).toHaveBeenCalledWith(null, 'loyola');
     });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'useOutdoorPOI: failed to get current position for POI search',
+      error,
+    );
   });
 });

--- a/mobile-app/components/MapScreen.tsx
+++ b/mobile-app/components/MapScreen.tsx
@@ -1040,6 +1040,7 @@ export default function MapScreen() {
   const isColorBlind = colourBlindMode;
   const brandRed = theme?.cred?.get?.() ?? '#b21b2c';
   const colourBlindAccent = theme?.colourBlind2?.get?.() ?? '#1F4E8C';
+  const poiMarkerColor = isColorBlind ? colourBlindAccent : brandRed;
   const routeColor = isColorBlind ? colourBlindAccent : brandRed;
   const defaultColor = theme?.cred?.get?.() ?? POLYGON_STROKE;
   const { polygonFillBase, polygonStrokeBase, polygonFillSelected } = getPolygonThemeColors(
@@ -2024,6 +2025,7 @@ export default function MapScreen() {
           <POIMarker
             key={`outdoor-poi-${poi.id}`}
             poi={poi}
+            markerColor={poiMarkerColor}
             testID={`outdoor-poi-marker-${poi.id}`}
             zIndex={POI_MARKER_Z_INDEX}
             iconName={

--- a/mobile-app/components/MapScreen.tsx
+++ b/mobile-app/components/MapScreen.tsx
@@ -674,52 +674,54 @@ export default function MapScreen() {
 
   /** Handle selecting an autocomplete result — room, building, or outdoor POI. */
   const handleSelectMergedResult = useCallback(
-    (result: {
-      id: string;
-      name: string;
-      address: string | null;
-      code: string | null;
-      _room?: any;
-      _poi?: OutdoorPOI;
-    }) => {
-      if (result.id.startsWith('room-') && (result as RoomSearchResult)._room) {
-        handleSelectRoomResult(result as RoomSearchResult);
-        return;
-      }
-      if (result.id.startsWith('poi-') && result._poi) {
-        const poi = result._poi;
-        handleCloseCard();
-        selectPOI(poi);
-        setSearchQuery(poi.name);
-        setIsSearchFocused(false);
-        searchInputRef.current?.blur();
-        mapRef.current?.animateToRegion(
-          {
-            ...poi.coordinate,
-            latitudeDelta: 0.01,
-            longitudeDelta: 0.01,
-          },
-          500,
-        );
-        return;
-      }
-      clearSelectedPOI();
-      handleSelectSearchResult(result as any);
-    },
-    [
-      indoor,
-      handleSelectSearchResult,
-      handleSelectRoomResult,
-      setSearchQuery,
-      setIsSearchFocused,
-      searchInputRef,
-      handleCloseCard,
-      selectPOI,
-      clearSelectedPOI,
-    ],
-  );
 
-  /** Navigate to the room from the info bubble. Uses GPS proximity to decide:
+const handleSelectMergedResult = useCallback(
+  (result: {
+    id: string;
+    name: string;
+    address: string | null;
+    code: string | null;
+    _room?: any;
+    _poi?: OutdoorPOI;
+  }) => {
+    if (result.id.startsWith('room-') && (result as RoomSearchResult)._room) {
+      handleSelectRoomResult(result as RoomSearchResult);
+      return;
+    }
+
+    if (result.id.startsWith('poi-') && result._poi) {
+      const poi = result._poi;
+      handleCloseCard();
+      selectPOI(poi);
+      setSearchQuery(poi.name);
+      setIsSearchFocused(false);
+      searchInputRef.current?.blur();
+      mapRef.current?.animateToRegion(
+        {
+          ...poi.coordinate,
+          latitudeDelta: 0.01,
+          longitudeDelta: 0.01,
+        },
+        500,
+      );
+      return;
+    }
+
+    clearSelectedPOI();
+    handleSelectSearchResult(result as any);
+  },
+  [
+    indoor,
+    handleSelectSearchResult,
+    handleSelectRoomResult,
+    setSearchQuery,
+    setIsSearchFocused,
+    searchInputRef,
+    handleCloseCard,
+    selectPOI,
+    clearSelectedPOI,
+  ],
+);  /** Navigate to the room from the info bubble. Uses GPS proximity to decide:
    *  if the user is near/inside the target building → indoor-only;
    *  if the user is far away → combined outdoor+indoor. */
   const handleRoomNavigate = useCallback(

--- a/mobile-app/components/MapScreen.tsx
+++ b/mobile-app/components/MapScreen.tsx
@@ -341,6 +341,7 @@ const HIDE_POIS_MAP_STYLE = [
 export default function MapScreen() {
   const mapRef = useRef<MapView>(null);
   const userPositionRef = useRef<{ latitude: number; longitude: number } | null>(null);
+  const [poiSearchLocation, setPoiSearchLocation] = useState<LatLng | null>(null);
   const { width, height } = Dimensions.get('window');
 
   // Use custom hooks for state management
@@ -472,7 +473,7 @@ export default function MapScreen() {
     clearSelectedPOI,
   } = useOutdoorPOI({
     debouncedQuery,
-    userLocation: userPositionRef.current,
+    userLocation: poiSearchLocation,
     activeCampus,
   });
 
@@ -1883,7 +1884,11 @@ export default function MapScreen() {
         }
         onUserLocationChange={(e) => {
           const c = e.nativeEvent.coordinate;
-          if (c) userPositionRef.current = { latitude: c.latitude, longitude: c.longitude };
+          if (!c) return;
+
+          const nextCoordinate = { latitude: c.latitude, longitude: c.longitude };
+          userPositionRef.current = nextCoordinate;
+          setPoiSearchLocation(nextCoordinate);
         }}
         onRegionChangeComplete={handleRegionChange}
         onPoiClick={(e) => {

--- a/mobile-app/components/MapScreen.tsx
+++ b/mobile-app/components/MapScreen.tsx
@@ -29,6 +29,7 @@ import FloorSelector from './indoor/FloorSelector';
 import RoomInfoBubble from './indoor/RoomInfoBubble';
 import PoiInfoBubble from './indoor/PoiInfoBubble';
 import IndoorStartPromptModal from './indoor/IndoorStartPromptModal';
+import POIMarker from './POIMarker';
 import {
   INDOOR_BUILDINGS,
   findBuildingAtCoordinate,
@@ -2019,11 +2020,14 @@ const handleSelectMergedResult = useCallback(
           />
         )}
         {outdoorPOIResults.map((poi) => (
-          <Marker
+          <POIMarker
             key={`outdoor-poi-${poi.id}`}
-            coordinate={poi.coordinate}
+            poi={poi}
             testID={`outdoor-poi-marker-${poi.id}`}
             zIndex={999}
+            iconName={
+              (POI_MARKER_ICONS[poi.category] ?? 'place') as keyof typeof MaterialIcons.glyphMap
+            }
             onPress={() => {
               poiPressedRef.current = true;
               requestAnimationFrame(() => {
@@ -2032,15 +2036,7 @@ const handleSelectMergedResult = useCallback(
               handleCloseCard();
               selectPOI(poi);
             }}
-          >
-            <View style={styles.poiMarkerPin}>
-              <MaterialIcons
-                name={POI_MARKER_ICONS[poi.category] ?? 'place'}
-                size={16}
-                color="#fff"
-              />
-            </View>
-          </Marker>
+          />
         ))}
       </MapView>
 
@@ -2559,20 +2555,5 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '600',
     color: '#333',
-  },
-  poiMarkerPin: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    backgroundColor: '#912338',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 2,
-    borderColor: '#fff',
-    shadowColor: '#000',
-    shadowOpacity: 0.3,
-    shadowOffset: { width: 0, height: 2 },
-    shadowRadius: 3,
-    elevation: 5,
   },
 });

--- a/mobile-app/components/MapScreen.tsx
+++ b/mobile-app/components/MapScreen.tsx
@@ -77,6 +77,10 @@ import {
   resolveEventLocation,
   type LocationConflict,
 } from '../utils/stringUtils';
+import { useOutdoorPOI } from '../hooks/useOutdoorPOI';
+import type { OutdoorPOI } from '../services/outdoorPOIService';
+import { isSupportedPOICategory } from '../services/outdoorPOIService';
+import OutdoorPOIInfoCard from './OutdoorPOIInfoCard';
 
 /** Format seconds into a compact label like "1 min" or "30 sec". */
 function formatIndoorTime(seconds: number): string {
@@ -307,6 +311,22 @@ const NORMALIZED_CURRENT_LOCATION = normalizeLabel('Current location');
 const INDOOR_ZOOM_THRESHOLD = 0.002;
 const INDOOR_NO_PATH_ERROR = 'No indoor route found between the given points';
 
+const POI_MARKER_ICONS: Record<string, string> = {
+  restaurant: 'restaurant',
+  cafe: 'local-cafe',
+  pharmacy: 'local-pharmacy',
+  gym: 'fitness-center',
+  bank: 'account-balance',
+  supermarket: 'shopping-cart',
+  bar: 'local-bar',
+  hospital: 'local-hospital',
+  library: 'local-library',
+  parking: 'local-parking',
+  gas_station: 'local-gas-station',
+  hotel: 'hotel',
+  place: 'place',
+};
+
 // Google Maps style that hides POI labels/icons (used when indoor overlay is active)
 const HIDE_POIS_MAP_STYLE = [
   { featureType: 'poi', elementType: 'labels', stylers: [{ visibility: 'off' }] },
@@ -402,6 +422,7 @@ export default function MapScreen() {
     lateTransportModes = [],
     routeSegments,
     openNavigationForResolvedDestination,
+    openNavigationForCoordinate,
     openIndoorOnlyNavigation,
     isIndoorOnlyRoute,
     isDestinationLocked,
@@ -437,6 +458,19 @@ export default function MapScreen() {
     const timer = setTimeout(() => setDebouncedQuery(searchQuery), 300);
     return () => clearTimeout(timer);
   }, [searchQuery]);
+
+  const {
+    outdoorPOIResults,
+    selectedOutdoorPOI,
+    isOutdoorPOILoading,
+    selectPOI,
+    selectPOIFromMap,
+    clearSelectedPOI,
+  } = useOutdoorPOI({
+    debouncedQuery,
+    userLocation: userPositionRef.current,
+    activeCampus,
+  });
 
   const {
     isMenuOpen,
@@ -593,10 +627,19 @@ export default function MapScreen() {
 
   type RoomSearchResult = (typeof roomSearchResults)[number];
 
+  const outdoorPOISearchResults = useMemo(() => {
+    return outdoorPOIResults.map((poi) => ({
+      id: `poi-${poi.id}`,
+      name: poi.name,
+      address: poi.address,
+      code: poi.category.replace(/_/g, ' '),
+      _poi: poi,
+    }));
+  }, [outdoorPOIResults]);
+
   const mergedSearchResults = useMemo(() => {
-    // Room results first, then building results
-    return [...roomSearchResults, ...searchResults];
-  }, [roomSearchResults, searchResults]);
+    return [...roomSearchResults, ...searchResults, ...outdoorPOISearchResults];
+  }, [roomSearchResults, searchResults, outdoorPOISearchResults]);
 
   const handleSelectRoomResult = useCallback(
     (result: RoomSearchResult) => {
@@ -629,7 +672,7 @@ export default function MapScreen() {
     [indoor, setSearchQuery, setIsSearchFocused],
   );
 
-  /** Handle selecting an autocomplete result — room or building. */
+  /** Handle selecting an autocomplete result — room, building, or outdoor POI. */
   const handleSelectMergedResult = useCallback(
     (result: {
       id: string;
@@ -637,16 +680,43 @@ export default function MapScreen() {
       address: string | null;
       code: string | null;
       _room?: any;
+      _poi?: OutdoorPOI;
     }) => {
-      // If it's a room result, select the room and show the bubble
       if (result.id.startsWith('room-') && (result as RoomSearchResult)._room) {
         handleSelectRoomResult(result as RoomSearchResult);
         return;
       }
-      // Otherwise delegate to the normal building search handler
+      if (result.id.startsWith('poi-') && result._poi) {
+        const poi = result._poi;
+        handleCloseCard();
+        selectPOI(poi);
+        setSearchQuery(poi.name);
+        setIsSearchFocused(false);
+        searchInputRef.current?.blur();
+        mapRef.current?.animateToRegion(
+          {
+            ...poi.coordinate,
+            latitudeDelta: 0.01,
+            longitudeDelta: 0.01,
+          },
+          500,
+        );
+        return;
+      }
+      clearSelectedPOI();
       handleSelectSearchResult(result as any);
     },
-    [indoor, handleSelectSearchResult, setSearchQuery, setIsSearchFocused, searchInputRef],
+    [
+      indoor,
+      handleSelectSearchResult,
+      handleSelectRoomResult,
+      setSearchQuery,
+      setIsSearchFocused,
+      searchInputRef,
+      handleCloseCard,
+      selectPOI,
+      clearSelectedPOI,
+    ],
   );
 
   /** Navigate to the room from the info bubble. Uses GPS proximity to decide:
@@ -698,6 +768,7 @@ export default function MapScreen() {
   );
 
   const roomPressedRef = useRef(false);
+  const poiPressedRef = useRef(false);
 
   /** Room marker tapped on the indoor overlay → toggle selection. */
   const handleRoomMarkerPress = useCallback(
@@ -1801,30 +1872,41 @@ export default function MapScreen() {
         showsUserLocation
         showsCompass={false}
         showsMyLocationButton={false}
-        showsPointsOfInterest={!indoor.isIndoorActive}
-        customMapStyle={indoor.isIndoorActive ? HIDE_POIS_MAP_STYLE : []}
+        showsPointsOfInterest={!indoor.isIndoorActive && outdoorPOIResults.length === 0}
+        customMapStyle={
+          indoor.isIndoorActive || outdoorPOIResults.length > 0 ? HIDE_POIS_MAP_STYLE : []
+        }
         onUserLocationChange={(e) => {
           const c = e.nativeEvent.coordinate;
           if (c) userPositionRef.current = { latitude: c.latitude, longitude: c.longitude };
         }}
         onRegionChangeComplete={handleRegionChange}
+        onPoiClick={(e) => {
+          const { placeId, name, coordinate } = e.nativeEvent;
+          if (!coordinate || !name) return;
+          handleCloseCard();
+          selectPOIFromMap({
+            id: placeId ?? `map-poi-${Date.now()}`,
+            name,
+            address: '',
+            coordinate: { latitude: coordinate.latitude, longitude: coordinate.longitude },
+            category: 'place',
+          });
+        }}
         onPress={(e) => {
-          // Always dismiss keyboard & search focus when tapping the map
           if (isSearchFocused) {
             Keyboard.dismiss();
             setIsSearchFocused(false);
           }
 
+          if (!poiPressedRef.current) clearSelectedPOI();
           const coordinate = e.nativeEvent?.coordinate;
           if (coordinate?.latitude != null && coordinate?.longitude != null) {
-            // When indoor mode is active, tapping empty space on the map should
-            // dismiss the selected room bubble rather than selecting the building.
-            // Skip if a room polygon was just tapped (iOS bubbles polygon press to map).
             if (indoor.isIndoorActive) {
               if (!roomPressedRef.current) indoor.selectRoom(null);
               return;
             }
-            handleMapCoordinatePress(coordinate);
+            if (!poiPressedRef.current) handleMapCoordinatePress(coordinate);
           }
         }}
       >
@@ -1934,6 +2016,30 @@ export default function MapScreen() {
             isColorBlind={isColorBlind}
           />
         )}
+        {outdoorPOIResults.map((poi) => (
+          <Marker
+            key={`outdoor-poi-${poi.id}`}
+            coordinate={poi.coordinate}
+            testID={`outdoor-poi-marker-${poi.id}`}
+            zIndex={999}
+            onPress={() => {
+              poiPressedRef.current = true;
+              requestAnimationFrame(() => {
+                poiPressedRef.current = false;
+              });
+              handleCloseCard();
+              selectPOI(poi);
+            }}
+          >
+            <View style={styles.poiMarkerPin}>
+              <MaterialIcons
+                name={POI_MARKER_ICONS[poi.category] ?? 'place'}
+                size={16}
+                color="#fff"
+              />
+            </View>
+          </Marker>
+        ))}
       </MapView>
 
       {/* Category filter chips */}
@@ -2046,6 +2152,12 @@ export default function MapScreen() {
             onSubmit={() => {
               // Try indoor destination first (e.g. "H-840"); fall back to normal building search
               if (!handleIndoorSearchQuery(searchQuery)) {
+                if (isSupportedPOICategory(searchQuery)) {
+                  if (mergedSearchResults.length > 0) {
+                    handleSelectMergedResult(mergedSearchResults[0]);
+                  }
+                  return;
+                }
                 handleSearchSubmit();
               }
             }}
@@ -2060,6 +2172,8 @@ export default function MapScreen() {
             brandColor={brandRed}
             logoSource={require('../assets/images/Concordia_icon.png')}
             onLogoPress={handleLogoPress}
+            blurOnSubmit={!isSupportedPOICategory(searchQuery)}
+            isLoading={isOutdoorPOILoading}
           />
           <View style={[styles.campusToggle, isNavigationOpen && styles.campusToggleNavigation]}>
             <CampusSwitch
@@ -2096,6 +2210,20 @@ export default function MapScreen() {
           openNavigationForBuilding(selectedBuilding, remoteBuilding);
           handleCloseCard();
         }}
+      />
+      <OutdoorPOIInfoCard
+        poi={isNavigationOpen ? null : selectedOutdoorPOI}
+        onClose={clearSelectedPOI}
+        isColorBlind={isColorBlind}
+        onDirections={
+          selectedOutdoorPOI
+            ? () => {
+                setArriveByClassEnd(null);
+                openNavigationForCoordinate(selectedOutdoorPOI.name, selectedOutdoorPOI.coordinate);
+                clearSelectedPOI();
+              }
+            : undefined
+        }
       />
       <NavigationScreen
         visible={isNavigationOpen && !isRoutePreviewOpen && !isDirectionsModeOpen}
@@ -2429,5 +2557,20 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '600',
     color: '#333',
+  },
+  poiMarkerPin: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: '#912338',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: '#fff',
+    shadowColor: '#000',
+    shadowOpacity: 0.3,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 3,
+    elevation: 5,
   },
 });

--- a/mobile-app/components/MapScreen.tsx
+++ b/mobile-app/components/MapScreen.tsx
@@ -288,6 +288,9 @@ const FEATURED_BUILDINGS: Record<Campus, QuickPick[]> = {
 
 const isSearchDisabled = false;
 const USER_LOCATION_REGION_DELTA = 0.01;
+const POI_REGION_DELTA = 0.01;
+const MAP_ANIMATION_DURATION_MS = 500;
+const POI_MARKER_Z_INDEX = 999;
 // 150m captures near-campus border usage; 800m caps snapping to plausible campus buildings only.
 const BORDER_THRESHOLD_METERS = 150;
 const NEAREST_BUILDING_MAX_METERS = 800;
@@ -449,7 +452,7 @@ export default function MapScreen() {
     const centroid = polygonCentroid(building.polygon);
     mapRef.current?.animateToRegion(
       { ...centroid, latitudeDelta: 0.0032, longitudeDelta: 0.0032 },
-      500,
+      MAP_ANIMATION_DURATION_MS,
     );
   });
 
@@ -667,7 +670,7 @@ export default function MapScreen() {
           latitudeDelta: 0.001,
           longitudeDelta: 0.001,
         },
-        500,
+        MAP_ANIMATION_DURATION_MS,
       );
     },
     [indoor, setSearchQuery, setIsSearchFocused],
@@ -675,54 +678,52 @@ export default function MapScreen() {
 
   /** Handle selecting an autocomplete result — room, building, or outdoor POI. */
   const handleSelectMergedResult = useCallback(
+    (result: {
+      id: string;
+      name: string;
+      address: string | null;
+      code: string | null;
+      _room?: any;
+      _poi?: OutdoorPOI;
+    }) => {
+      if (result.id.startsWith('room-') && (result as RoomSearchResult)._room) {
+        handleSelectRoomResult(result as RoomSearchResult);
+        return;
+      }
+      if (result.id.startsWith('poi-') && result._poi) {
+        const poi = result._poi;
+        handleCloseCard();
+        selectPOI(poi);
+        setSearchQuery(poi.name);
+        setIsSearchFocused(false);
+        searchInputRef.current?.blur();
+        mapRef.current?.animateToRegion(
+          {
+            ...poi.coordinate,
+            latitudeDelta: POI_REGION_DELTA,
+            longitudeDelta: POI_REGION_DELTA,
+          },
+          MAP_ANIMATION_DURATION_MS,
+        );
+        return;
+      }
+      clearSelectedPOI();
+      handleSelectSearchResult(result as any);
+    },
+    [
+      indoor,
+      handleSelectSearchResult,
+      handleSelectRoomResult,
+      setSearchQuery,
+      setIsSearchFocused,
+      searchInputRef,
+      handleCloseCard,
+      selectPOI,
+      clearSelectedPOI,
+    ],
+  );
 
-const handleSelectMergedResult = useCallback(
-  (result: {
-    id: string;
-    name: string;
-    address: string | null;
-    code: string | null;
-    _room?: any;
-    _poi?: OutdoorPOI;
-  }) => {
-    if (result.id.startsWith('room-') && (result as RoomSearchResult)._room) {
-      handleSelectRoomResult(result as RoomSearchResult);
-      return;
-    }
-
-    if (result.id.startsWith('poi-') && result._poi) {
-      const poi = result._poi;
-      handleCloseCard();
-      selectPOI(poi);
-      setSearchQuery(poi.name);
-      setIsSearchFocused(false);
-      searchInputRef.current?.blur();
-      mapRef.current?.animateToRegion(
-        {
-          ...poi.coordinate,
-          latitudeDelta: 0.01,
-          longitudeDelta: 0.01,
-        },
-        500,
-      );
-      return;
-    }
-
-    clearSelectedPOI();
-    handleSelectSearchResult(result as any);
-  },
-  [
-    indoor,
-    handleSelectSearchResult,
-    handleSelectRoomResult,
-    setSearchQuery,
-    setIsSearchFocused,
-    searchInputRef,
-    handleCloseCard,
-    selectPOI,
-    clearSelectedPOI,
-  ],
-);  /** Navigate to the room from the info bubble. Uses GPS proximity to decide:
+  /** Navigate to the room from the info bubble. Uses GPS proximity to decide:
    *  if the user is near/inside the target building → indoor-only;
    *  if the user is far away → combined outdoor+indoor. */
   const handleRoomNavigate = useCallback(
@@ -1115,7 +1116,7 @@ const handleSelectMergedResult = useCallback(
     const centroid = polygonCentroid(match.polygon);
     mapRef.current?.animateToRegion(
       { ...centroid, latitudeDelta: 0.0032, longitudeDelta: 0.0032 },
-      500,
+      MAP_ANIMATION_DURATION_MS,
     );
   };
 
@@ -1304,7 +1305,7 @@ const handleSelectMergedResult = useCallback(
             latitudeDelta: USER_LOCATION_REGION_DELTA,
             longitudeDelta: USER_LOCATION_REGION_DELTA,
           },
-          500,
+          MAP_ANIMATION_DURATION_MS,
         );
       },
     });
@@ -2024,7 +2025,7 @@ const handleSelectMergedResult = useCallback(
             key={`outdoor-poi-${poi.id}`}
             poi={poi}
             testID={`outdoor-poi-marker-${poi.id}`}
-            zIndex={999}
+            zIndex={POI_MARKER_Z_INDEX}
             iconName={
               (POI_MARKER_ICONS[poi.category] ?? 'place') as keyof typeof MaterialIcons.glyphMap
             }

--- a/mobile-app/components/OutdoorPOIInfoCard.tsx
+++ b/mobile-app/components/OutdoorPOIInfoCard.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useTheme } from 'tamagui';
+import type { OutdoorPOI } from '../services/outdoorPOIService';
+import DirectionButton from './DirectionButton';
+
+interface OutdoorPOIInfoCardProps {
+  poi: OutdoorPOI | null;
+  onClose: () => void;
+  onDirections?: () => void;
+  isColorBlind: boolean;
+}
+
+export default function OutdoorPOIInfoCard({
+  poi,
+  onClose,
+  onDirections,
+  isColorBlind,
+}: Readonly<OutdoorPOIInfoCardProps>) {
+  const theme = useTheme();
+
+  if (!poi) return null;
+
+  const brandRed = theme.cred?.val ?? '#b21b2c';
+  const colourBlindPrimary = theme.colourBlind2?.val ?? brandRed;
+  const colourBlindSecondary = theme.colourBlind1?.val ?? '#B3D4FF';
+  const accentColor = isColorBlind ? colourBlindPrimary : brandRed;
+  const directionTextColor = isColorBlind ? colourBlindPrimary : '#fff';
+  const directionButtonColor = isColorBlind ? colourBlindSecondary : brandRed;
+
+  const categoryLabel = poi.category.replace(/_/g, ' ');
+
+  return (
+    <View style={styles.overlay} pointerEvents="box-none">
+      <Pressable style={styles.backdrop} onPress={onClose} />
+      <View style={styles.cardWrapper} pointerEvents="box-none">
+        <View style={styles.card}>
+          <Pressable
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Close POI details"
+            style={styles.closeButton}
+            testID="poi-close-button"
+          >
+            <MaterialIcons name="close" size={21} color={accentColor} />
+          </Pressable>
+
+          <Text style={styles.title} numberOfLines={2} testID="poi-name">
+            {poi.name}
+          </Text>
+          <Text style={styles.address} numberOfLines={1} testID="poi-address">
+            {poi.address || 'Address unavailable'}
+          </Text>
+
+          <View style={styles.metaRow}>
+            <View style={[styles.categoryBadge, { backgroundColor: accentColor }]}>
+              <MaterialIcons name="place" size={14} color="#fff" />
+              <Text style={styles.categoryText} testID="poi-category">
+                {categoryLabel}
+              </Text>
+            </View>
+
+            {poi.rating != null && (
+              <View style={styles.ratingWrap}>
+                <MaterialIcons name="star" size={16} color="#f5a623" />
+                <Text style={styles.ratingText} testID="poi-rating">
+                  {poi.rating.toFixed(1)}
+                </Text>
+              </View>
+            )}
+
+            {poi.openNow != null && (
+              <Text
+                style={[styles.openStatus, { color: poi.openNow ? '#2e7d32' : '#c62828' }]}
+                testID="poi-open-status"
+              >
+                {poi.openNow ? 'Open now' : 'Closed'}
+              </Text>
+            )}
+          </View>
+
+          <DirectionButton
+            onPress={onDirections}
+            disabled={!onDirections}
+            backgroundColor={directionButtonColor}
+            textColor={directionTextColor}
+            iconColor={directionTextColor}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1,
+  },
+  cardWrapper: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    top: '35%',
+    alignItems: 'center',
+    zIndex: 2,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 456,
+    backgroundColor: '#f7f2f2',
+    borderRadius: 24,
+    padding: 22,
+    borderWidth: 1,
+    borderColor: '#efd9d9',
+    shadowColor: '#000',
+    shadowOpacity: 0.18,
+    shadowRadius: 10,
+    elevation: 6,
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 9,
+    right: 9,
+    padding: 4,
+    zIndex: 3,
+  },
+  title: { fontSize: 22, fontWeight: '700', color: '#1c1c1e', paddingRight: 20 },
+  address: { fontSize: 17, color: '#6b6b6b', marginTop: 4 },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    marginTop: 10,
+    gap: 8,
+  },
+  categoryBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+    gap: 4,
+  },
+  categoryText: { fontSize: 13, fontWeight: '600', color: '#fff' },
+  ratingWrap: { flexDirection: 'row', alignItems: 'center', gap: 2 },
+  ratingText: { fontSize: 14, fontWeight: '600', color: '#4a4a4a' },
+  openStatus: { fontSize: 14, fontWeight: '600' },
+});

--- a/mobile-app/components/POIMarker.tsx
+++ b/mobile-app/components/POIMarker.tsx
@@ -10,12 +10,20 @@ type Props = {
   onPress?: () => void;
   testID?: string;
   zIndex?: number;
+  markerColor?: string;
 };
 
-export default function POIMarker({ poi, iconName = 'place', onPress, testID, zIndex }: Props) {
+export default function POIMarker({
+  poi,
+  iconName = 'place',
+  onPress,
+  testID,
+  zIndex,
+  markerColor = '#912338',
+}: Props) {
   return (
     <Marker coordinate={poi.coordinate} testID={testID} zIndex={zIndex} onPress={onPress}>
-      <View style={styles.markerPin}>
+      <View style={[styles.markerPin, { backgroundColor: markerColor }]}>
         <MaterialIcons name={iconName} size={16} color="#fff" />
       </View>
     </Marker>
@@ -27,7 +35,6 @@ const styles = StyleSheet.create({
     width: 32,
     height: 32,
     borderRadius: 16,
-    backgroundColor: '#912338',
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 2,

--- a/mobile-app/components/POIMarker.tsx
+++ b/mobile-app/components/POIMarker.tsx
@@ -12,14 +12,14 @@ type Props = {
   zIndex?: number;
   markerColor?: string;
 };
-const DEFAULT_MARKER_COLOR = '#912338';
+
 export default function POIMarker({
   poi,
   iconName = 'place',
   onPress,
   testID,
   zIndex,
-  markerColor = DEFAULT_MARKER_COLOR,
+  markerColor = '#912338',
 }: Props) {
   return (
     <Marker coordinate={poi.coordinate} testID={testID} zIndex={zIndex} onPress={onPress}>

--- a/mobile-app/components/POIMarker.tsx
+++ b/mobile-app/components/POIMarker.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Marker } from 'react-native-maps';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import type { OutdoorPOI } from '../services/outdoorPOIService';
+
+type Props = {
+  poi: OutdoorPOI;
+  iconName?: keyof typeof MaterialIcons.glyphMap;
+  onPress?: () => void;
+  testID?: string;
+  zIndex?: number;
+};
+
+export default function POIMarker({ poi, iconName = 'place', onPress, testID, zIndex }: Props) {
+  return (
+    <Marker coordinate={poi.coordinate} testID={testID} zIndex={zIndex} onPress={onPress}>
+      <View style={styles.markerPin}>
+        <MaterialIcons name={iconName} size={16} color="#fff" />
+      </View>
+    </Marker>
+  );
+}
+
+const styles = StyleSheet.create({
+  markerPin: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: '#912338',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: '#fff',
+    shadowColor: '#000',
+    shadowOpacity: 0.3,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 3,
+    elevation: 5,
+  },
+});

--- a/mobile-app/components/POIMarker.tsx
+++ b/mobile-app/components/POIMarker.tsx
@@ -12,14 +12,14 @@ type Props = {
   zIndex?: number;
   markerColor?: string;
 };
-
+const DEFAULT_MARKER_COLOR = '#912338';
 export default function POIMarker({
   poi,
   iconName = 'place',
   onPress,
   testID,
   zIndex,
-  markerColor = '#912338',
+  markerColor = DEFAULT_MARKER_COLOR,
 }: Props) {
   return (
     <Marker coordinate={poi.coordinate} testID={testID} zIndex={zIndex} onPress={onPress}>

--- a/mobile-app/components/SearchBar.tsx
+++ b/mobile-app/components/SearchBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  ActivityIndicator,
   Image,
   Pressable,
   Text,
@@ -33,6 +34,8 @@ interface SearchBarProps {
   brandColor: string;
   logoSource: ImageSourcePropType;
   onLogoPress?: () => void;
+  blurOnSubmit?: boolean;
+  isLoading?: boolean;
 }
 
 export default function SearchBar({
@@ -50,6 +53,8 @@ export default function SearchBar({
   brandColor,
   logoSource,
   onLogoPress,
+  blurOnSubmit = true,
+  isLoading = false,
 }: Readonly<SearchBarProps>) {
   return (
     <>
@@ -69,6 +74,7 @@ export default function SearchBar({
             returnKeyType="search"
             inputAccessoryViewID="searchBar"
             onSubmitEditing={onSubmit}
+            blurOnSubmit={blurOnSubmit}
             onFocus={onFocus}
             onBlur={onBlur}
             editable={!isSearchDisabled}
@@ -97,8 +103,14 @@ export default function SearchBar({
         </Pressable>
       </View>
 
-      {!isSearchDisabled && isSearchFocused && searchResults.length > 0 && (
+      {!isSearchDisabled && isSearchFocused && (searchResults.length > 0 || isLoading) && (
         <View style={styles.mapSearchResults} testID="map-search-results">
+          {isLoading && searchResults.length === 0 && (
+            <View style={styles.mapSearchLoadingItem} testID="search-loading">
+              <ActivityIndicator size="small" color="#8c8c8c" />
+              <Text style={styles.mapSearchLoadingText}>Searching nearby places…</Text>
+            </View>
+          )}
           {searchResults.map((result, index) => (
             <Pressable
               key={`${result.id}-${result.name}`}
@@ -173,6 +185,14 @@ const styles = StyleSheet.create({
   },
   mapSearchResultTitle: { fontSize: 16, fontWeight: '600', color: '#2b2b2b' },
   mapSearchResultMeta: { fontSize: 14, color: '#6b6b6b', marginTop: 2 },
+  mapSearchLoadingItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    gap: 10,
+  },
+  mapSearchLoadingText: { fontSize: 14, color: '#8c8c8c' },
   mapBrandBadge: {
     width: 55,
     height: 55,

--- a/mobile-app/hooks/useNavigationBetweenBuildings.ts
+++ b/mobile-app/hooks/useNavigationBetweenBuildings.ts
@@ -12,7 +12,8 @@ import {
   type LatLng,
 } from '../utils/mapUtils';
 import { extractCodeFromName, normalizeLabel } from '../utils/stringUtils';
-const MAX_TAP_DISTANCE_METERS = 5;
+
+const MAX_TAP_DISTANCE_METERS = 0;
 
 /** Decode a Google-encoded polyline string into an array of LatLng. */
 function decodePolyline(encoded: string): LatLng[] {

--- a/mobile-app/hooks/useNavigationBetweenBuildings.ts
+++ b/mobile-app/hooks/useNavigationBetweenBuildings.ts
@@ -12,8 +12,7 @@ import {
   type LatLng,
 } from '../utils/mapUtils';
 import { extractCodeFromName, normalizeLabel } from '../utils/stringUtils';
-
-const MAX_TAP_DISTANCE_METERS = 0;
+const MAX_TAP_DISTANCE_METERS = 5;
 
 /** Decode a Google-encoded polyline string into an array of LatLng. */
 function decodePolyline(encoded: string): LatLng[] {

--- a/mobile-app/hooks/useNavigationBetweenBuildings.ts
+++ b/mobile-app/hooks/useNavigationBetweenBuildings.ts
@@ -13,7 +13,7 @@ import {
 } from '../utils/mapUtils';
 import { extractCodeFromName, normalizeLabel } from '../utils/stringUtils';
 
-const MAX_TAP_DISTANCE_METERS = 80;
+const MAX_TAP_DISTANCE_METERS = 0;
 
 /** Decode a Google-encoded polyline string into an array of LatLng. */
 function decodePolyline(encoded: string): LatLng[] {
@@ -1225,6 +1225,22 @@ export function useNavigationBetweenBuildings({
     [resetRouteState],
   );
 
+  const openNavigationForCoordinate = useCallback(
+    (label: string, coordinate: LatLng) => {
+      setIsDestinationLocked(false);
+      setIsIndoorOnlyRoute(false);
+      setNavigationStart('Your location');
+      setNavigationOrigin(null);
+      setNavigationDestination(label);
+      setNavigationDestinationCoord(coordinate);
+      setTapMarkerCoordinate(coordinate);
+      setActiveMode('driving');
+      resetRouteState();
+      setIsNavigationOpen(true);
+    },
+    [resetRouteState],
+  );
+
   const handleMapBuildingPress = useCallback(
     (buildingId: string) => {
       const building = buildings.find((b) => b.id === buildingId);
@@ -1416,6 +1432,7 @@ export function useNavigationBetweenBuildings({
     setActiveMode,
     openNavigationForBuilding,
     openNavigationForResolvedDestination,
+    openNavigationForCoordinate,
     openIndoorOnlyNavigation,
     isIndoorOnlyRoute,
     handleMapBuildingPress,

--- a/mobile-app/hooks/useOutdoorPOI.ts
+++ b/mobile-app/hooks/useOutdoorPOI.ts
@@ -89,21 +89,35 @@ export function useOutdoorPOI({
   }, []);
 
   /** Select a POI from the map and resolve its address via device geocoding. */
-  const selectPOIFromMap = useCallback((basePOI: OutdoorPOI) => {
-    setSelectedOutdoorPOI(basePOI);
-    if (!basePOI.address) {
-      Location.reverseGeocodeAsync(basePOI.coordinate)
-        .then((results) => {
-          if (results.length === 0) return;
-          const address = results[0].formattedAddress || formatGeocodedAddress(results[0]);
-          if (!address) return;
-          setSelectedOutdoorPOI((prev) => (prev?.id === basePOI.id ? { ...prev, address } : prev));
-        })
-        .catch((error) => {
-          console.warn('useOutdoorPOI: reverse geocoding failed for selected POI', error);
-        });
-    }
-  }, []);
+const selectPOIFromMap = useCallback((basePOI: OutdoorPOI) => {
+  let isActive = true;
+
+  setSelectedOutdoorPOI(basePOI);
+
+  if (!basePOI.address) {
+    Location.reverseGeocodeAsync(basePOI.coordinate)
+      .then((results) => {
+        if (!isActive || results.length === 0) return;
+
+        const address =
+          results[0].formattedAddress || formatGeocodedAddress(results[0]);
+
+        if (!isActive || !address) return;
+
+        setSelectedOutdoorPOI((prev) =>
+          isActive && prev?.id === basePOI.id ? { ...prev, address } : prev,
+        );
+      })
+      .catch((error) => {
+        if (!isActive) return;
+        console.warn('useOutdoorPOI: reverse geocoding failed for selected POI', error);
+      });
+  }
+
+  return () => {
+    isActive = false;
+  };
+}, []);
 
   const clearSelectedPOI = useCallback(() => {
     setSelectedOutdoorPOI(null);

--- a/mobile-app/hooks/useOutdoorPOI.ts
+++ b/mobile-app/hooks/useOutdoorPOI.ts
@@ -49,7 +49,8 @@ export function useOutdoorPOI({
           accuracy: Location.Accuracy.Balanced,
         });
         return { latitude: loc.coords.latitude, longitude: loc.coords.longitude };
-      } catch {
+      } catch (error) {
+        console.warn('useOutdoorPOI: failed to get current position for POI search', error);
         return getCampusCenterForPOI(null, activeCampus);
       }
     };
@@ -85,7 +86,9 @@ export function useOutdoorPOI({
           if (!address) return;
           setSelectedOutdoorPOI((prev) => (prev?.id === basePOI.id ? { ...prev, address } : prev));
         })
-        .catch(() => {});
+        .catch((error) => {
+          console.warn('useOutdoorPOI: reverse geocoding failed for selected POI', error);
+        });
     }
   }, []);
 

--- a/mobile-app/hooks/useOutdoorPOI.ts
+++ b/mobile-app/hooks/useOutdoorPOI.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import * as Location from 'expo-location';
 import {
   isSupportedPOICategory,
@@ -29,7 +29,6 @@ export function useOutdoorPOI({
   const [outdoorPOIResults, setOutdoorPOIResults] = useState<OutdoorPOI[]>([]);
   const [selectedOutdoorPOI, setSelectedOutdoorPOI] = useState<OutdoorPOI | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const fetchIdRef = useRef(0);
 
   useEffect(() => {
     const category = isSupportedPOICategory(debouncedQuery);
@@ -39,7 +38,7 @@ export function useOutdoorPOI({
       return;
     }
 
-    const id = ++fetchIdRef.current;
+    const controller = new AbortController();
     setIsLoading(true);
 
     const resolveCenter = async (): Promise<LatLng> => {
@@ -55,20 +54,34 @@ export function useOutdoorPOI({
       }
     };
 
-    resolveCenter()
-      .then((center) => fetchNearbyPOIs(category, center, POI_SEARCH_RADIUS_METERS))
-      .then((results) => {
-        if (id !== fetchIdRef.current) return;
+    const loadPOIs = async () => {
+      try {
+        const center = await resolveCenter();
+        if (controller.signal.aborted) return;
+
+        const results = await fetchNearbyPOIs(
+          category,
+          center,
+          POI_SEARCH_RADIUS_METERS,
+          controller.signal,
+        );
+        if (controller.signal.aborted) return;
+
         setOutdoorPOIResults(results);
-      })
-      .catch(() => {
-        if (id !== fetchIdRef.current) return;
+      } catch {
+        if (controller.signal.aborted) return;
         setOutdoorPOIResults([]);
-      })
-      .finally(() => {
-        if (id !== fetchIdRef.current) return;
+      } finally {
+        if (controller.signal.aborted) return;
         setIsLoading(false);
-      });
+      }
+    };
+
+    void loadPOIs();
+
+    return () => {
+      controller.abort();
+    };
   }, [debouncedQuery, userLocation, activeCampus]);
 
   const selectPOI = useCallback((poi: OutdoorPOI) => {

--- a/mobile-app/hooks/useOutdoorPOI.ts
+++ b/mobile-app/hooks/useOutdoorPOI.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as Location from 'expo-location';
+import {
+  isSupportedPOICategory,
+  fetchNearbyPOIs,
+  getCampusCenterForPOI,
+  type OutdoorPOI,
+} from '../services/outdoorPOIService';
+import type { LatLng } from '../utils/mapUtils';
+
+function formatGeocodedAddress(geo: Location.LocationGeocodedAddress): string {
+  const street = [geo.streetNumber, geo.street].filter(Boolean).join(' ');
+  return [street, geo.city, geo.region].filter(Boolean).join(', ');
+}
+
+const POI_SEARCH_RADIUS_METERS = 1000;
+
+interface UseOutdoorPOIOptions {
+  debouncedQuery: string;
+  userLocation: LatLng | null;
+  activeCampus: 'sgw' | 'loyola';
+}
+
+export function useOutdoorPOI({
+  debouncedQuery,
+  userLocation,
+  activeCampus,
+}: UseOutdoorPOIOptions) {
+  const [outdoorPOIResults, setOutdoorPOIResults] = useState<OutdoorPOI[]>([]);
+  const [selectedOutdoorPOI, setSelectedOutdoorPOI] = useState<OutdoorPOI | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const fetchIdRef = useRef(0);
+
+  useEffect(() => {
+    const category = isSupportedPOICategory(debouncedQuery);
+    if (!category) {
+      setOutdoorPOIResults([]);
+      setIsLoading(false);
+      return;
+    }
+
+    const id = ++fetchIdRef.current;
+    setIsLoading(true);
+
+    const resolveCenter = async (): Promise<LatLng> => {
+      if (userLocation) return userLocation;
+      try {
+        const loc = await Location.getCurrentPositionAsync({
+          accuracy: Location.Accuracy.Balanced,
+        });
+        return { latitude: loc.coords.latitude, longitude: loc.coords.longitude };
+      } catch {
+        return getCampusCenterForPOI(null, activeCampus);
+      }
+    };
+
+    resolveCenter()
+      .then((center) => fetchNearbyPOIs(category, center, POI_SEARCH_RADIUS_METERS))
+      .then((results) => {
+        if (id !== fetchIdRef.current) return;
+        setOutdoorPOIResults(results);
+      })
+      .catch(() => {
+        if (id !== fetchIdRef.current) return;
+        setOutdoorPOIResults([]);
+      })
+      .finally(() => {
+        if (id !== fetchIdRef.current) return;
+        setIsLoading(false);
+      });
+  }, [debouncedQuery, userLocation, activeCampus]);
+
+  const selectPOI = useCallback((poi: OutdoorPOI) => {
+    setSelectedOutdoorPOI(poi);
+  }, []);
+
+  /** Select a POI from the map and resolve its address via device geocoding. */
+  const selectPOIFromMap = useCallback((basePOI: OutdoorPOI) => {
+    setSelectedOutdoorPOI(basePOI);
+    if (!basePOI.address) {
+      Location.reverseGeocodeAsync(basePOI.coordinate)
+        .then((results) => {
+          if (results.length === 0) return;
+          const address = results[0].formattedAddress || formatGeocodedAddress(results[0]);
+          if (!address) return;
+          setSelectedOutdoorPOI((prev) => (prev?.id === basePOI.id ? { ...prev, address } : prev));
+        })
+        .catch(() => {});
+    }
+  }, []);
+
+  const clearSelectedPOI = useCallback(() => {
+    setSelectedOutdoorPOI(null);
+  }, []);
+
+  return {
+    outdoorPOIResults,
+    selectedOutdoorPOI,
+    isOutdoorPOILoading: isLoading,
+    selectPOI,
+    selectPOIFromMap,
+    clearSelectedPOI,
+  };
+}

--- a/mobile-app/services/outdoorPOIService.ts
+++ b/mobile-app/services/outdoorPOIService.ts
@@ -1,0 +1,146 @@
+import { Platform } from 'react-native';
+import { getCampusFromCoordinate, distanceMeters, type LatLng } from '../utils/mapUtils';
+
+export type OutdoorPOI = {
+  id: string;
+  name: string;
+  address: string;
+  coordinate: LatLng;
+  category: string;
+  rating?: number;
+  openNow?: boolean;
+};
+
+const SGW_CENTER: LatLng = { latitude: 45.4973, longitude: -73.5789 };
+const LOYOLA_CENTER: LatLng = { latitude: 45.4581, longitude: -73.6402 };
+
+const POI_CATEGORY_MAP: Record<string, string> = {
+  restaurant: 'restaurant',
+  restaurants: 'restaurant',
+  food: 'restaurant',
+  pharmacy: 'pharmacy',
+  drugstore: 'pharmacy',
+  cafe: 'cafe',
+  coffee: 'cafe',
+  coffeeshop: 'cafe',
+  gym: 'gym',
+  bank: 'bank',
+  supermarket: 'supermarket',
+  grocery: 'supermarket',
+  bar: 'bar',
+  hospital: 'hospital',
+  library: 'library',
+  parking: 'parking',
+  gas_station: 'gas_station',
+  gas: 'gas_station',
+  hotel: 'hotel',
+};
+
+export const SUPPORTED_CATEGORIES = [...new Set(Object.values(POI_CATEGORY_MAP))];
+
+/**
+ * Returns the Google Places type if the query matches a supported outdoor POI
+ * category, or null otherwise.
+ */
+export function isSupportedPOICategory(query: string): string | null {
+  const normalized = query.trim().toLowerCase();
+  return POI_CATEGORY_MAP[normalized] ?? null;
+}
+
+function getPlacesKey(): string {
+  if (Platform.OS === 'ios') {
+    return process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_IOS ?? '';
+  }
+  return process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY_ANDROID ?? '';
+}
+
+/**
+ * Fetch nearby outdoor POIs from Google Places Nearby Search.
+ * Uses `rankby=distance` so the API returns results ordered by proximity
+ * to `center`, then applies a client-side distance cap at `radiusMeters`.
+ */
+export async function fetchNearbyPOIs(
+  type: string,
+  center: LatLng,
+  radiusMeters: number,
+): Promise<OutdoorPOI[]> {
+  const key = getPlacesKey();
+  if (!key) return [];
+
+  const url =
+    `https://maps.googleapis.com/maps/api/place/nearbysearch/json` +
+    `?location=${center.latitude},${center.longitude}` +
+    `&rankby=distance` +
+    `&type=${type}` +
+    `&key=${key}`;
+
+  const response = await fetch(url);
+  if (!response.ok) return [];
+
+  const data = await response.json();
+  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') return [];
+  if (!Array.isArray(data.results)) return [];
+
+  const pois: OutdoorPOI[] = data.results
+    .map((place: any) => ({
+      id: place.place_id ?? '',
+      name: place.name ?? '',
+      address: place.vicinity ?? '',
+      coordinate: {
+        latitude: place.geometry?.location?.lat ?? 0,
+        longitude: place.geometry?.location?.lng ?? 0,
+      },
+      category: type,
+      rating: place.rating,
+      openNow: place.opening_hours?.open_now,
+    }))
+    .filter((poi: OutdoorPOI) => distanceMeters(center, poi.coordinate) <= radiusMeters);
+
+  return pois;
+}
+
+/**
+ * Fetch place details (address, rating, hours) from Google Places Details API.
+ * Used to enrich POIs selected via the map's onPoiClick which only provides
+ * placeId, name, and coordinate.
+ */
+export async function fetchPlaceDetails(
+  placeId: string,
+): Promise<{ address: string; rating?: number; openNow?: boolean }> {
+  const key = getPlacesKey();
+  if (!key) return { address: '' };
+
+  const url =
+    `https://maps.googleapis.com/maps/api/place/details/json` +
+    `?place_id=${placeId}` +
+    `&fields=formatted_address,rating,opening_hours` +
+    `&key=${key}`;
+
+  const response = await fetch(url);
+  if (!response.ok) return { address: '' };
+
+  const data = await response.json();
+  if (data.status !== 'OK' || !data.result) return { address: '' };
+
+  return {
+    address: data.result.formatted_address ?? '',
+    rating: data.result.rating,
+    openNow: data.result.opening_hours?.open_now,
+  };
+}
+
+/**
+ * Determine the center point for a POI search.
+ * If the user is on a campus, use their location; otherwise fall back to
+ * the center of the currently active campus.
+ */
+export function getCampusCenterForPOI(
+  userLocation: LatLng | null,
+  activeCampus: 'sgw' | 'loyola',
+): LatLng {
+  if (userLocation) {
+    const campus = getCampusFromCoordinate(userLocation);
+    if (campus) return userLocation;
+  }
+  return activeCampus === 'loyola' ? LOYOLA_CENTER : SGW_CENTER;
+}

--- a/mobile-app/services/outdoorPOIService.ts
+++ b/mobile-app/services/outdoorPOIService.ts
@@ -101,9 +101,8 @@ export async function fetchNearbyPOIs(
 }
 
 /**
- * Fetch place details (address, rating, hours) from Google Places Details API.
- * Used to enrich POIs selected via the map's onPoiClick which only provides
- * placeId, name, and coordinate.
+ * Fetch place details (address, rating, hours) from the Google Places Details API.
+ * Can be used to enrich a POI when only a placeId is initially available.
  */
 export async function fetchPlaceDetails(
   placeId: string,

--- a/mobile-app/services/outdoorPOIService.ts
+++ b/mobile-app/services/outdoorPOIService.ts
@@ -63,6 +63,7 @@ export async function fetchNearbyPOIs(
   type: string,
   center: LatLng,
   radiusMeters: number,
+  signal?: AbortSignal,
 ): Promise<OutdoorPOI[]> {
   const key = getPlacesKey();
   if (!key) return [];
@@ -74,7 +75,7 @@ export async function fetchNearbyPOIs(
     `&type=${type}` +
     `&key=${key}`;
 
-  const response = await fetch(url);
+  const response = await fetch(url, { signal });
   if (!response.ok) return [];
 
   const data = await response.json();


### PR DESCRIPTION
# Notes:
- This PR closes #46 
and all its sub-issues:
  - closes #47 
    - closes #285 
  - closes #48 
    - closes #286  
 
- This Epic was implemented by one person due to its issues being closely related. hence, we also decided to make one PR for the whole feature 

Acceptance Criteria:
- [x] A route action is available for POIs.
- [x] Directions are displayed on the map.
- [x] Switching POIs updates the route.
- [x] POIs can be filtered by type and range.
- [x] Results are sorted by distance ( we should only show POIs 10KM around the campus)
  
---

# Outdoor Points of Interest (POI) Feature (Last feature! 🎉)
 
## Overview
 
This PR introduces an Outdoor POIs feature that lets users discover nearby points of interest (restaurants, cafes, pharmacies, etc.) around Concordia's SGW and Loyola campuses, view details about them, and navigate to them — along with comprehensive unit tests covering the new services, components, and navigation logic.
 
---
 
## Feature Behavior
 
### Default (no search)
 
Google Maps' native POIs remain visible on the map as usual. Tapping any native POI opens an info card showing the name, address (resolved asynchronously via `expo-location`'s `reverseGeocodeAsync` — no API key required), category, and a Directions button. Pressing Directions starts coordinate-based navigation to that POI; it is treated as a generic destination, not a campus building.
 
### Search
 
When a user types a supported category (e.g. `restaurant`, `cafe`, `pharmacy`) in the search bar:
 
- A "Searching nearby places…" loading indicator appears in the dropdown while results are fetched. The keyboard does not auto-dismiss on submit, keeping the dropdown visible.
- Results appear with name, address, and category.
- On selection or Enter, Google's native POIs are hidden and replaced with custom markers — 32px Concordia-red circles with a white border and a category-specific icon (fork/knife for restaurants, coffee cup for cafes, etc.). Markers render above building polygons via a high z-index, so tapping a marker on a building registers as a POI tap.
- Clearing the search bar removes custom markers and restores native POIs.
 
### Search Radius & Centering
 

- Results are fetched within a 1km radius centered on the user's GPS location (`Location.getCurrentPositionAsync`), falling back to the active campus center (SGW or Loyola) if GPS is unavailable. The Google Places API is called with `rankby=distance`; a client-side filter enforces the 1km cap.
- Results are ranked by distance, so users see the closest matches first. By design, we currently consume only the first Google Places Nearby Search page (up to 20 results) and do not paginate with next_page_token. This is an intentional strategy to keep the map readable (reduce marker clutter around campus) and to control Places API usage/quota by avoiding unnecessary follow-up requests.

 
### Supported Categories
 
| Search terms | Google Places type |
|---|---|
| `restaurant`, `restaurants`, `food` | `restaurant` |
| `cafe`, `coffee`, `coffeeshop` | `cafe` |
| `pharmacy`, `drugstore` | `pharmacy` |
| `gym` | `gym` |
| `bank` | `bank` |
| `supermarket`, `grocery` | `supermarket` |
| `bar` | `bar` |
| `hospital` | `hospital` |
| `library` | `library` |
| `parking` | `parking` |
| `gas`, `gas_station` | `gas_station` |
| `hotel` | `hotel` |
 
All terms are case-insensitive and whitespace-trimmed.
 
### POI Info Card
 
Displays name, address, category badge, rating (if available), and open/closed status (if available). Has a close button and tappable backdrop to dismiss, plus a Directions button that triggers `openNavigationForCoordinate(label, coordinate)` — a coordinate-based path that does not treat the destination as a campus building.
 
---
 
## Architecture
 
- `outdoorPOIService.ts` — category resolution (`isSupportedPOICategory`), Google Places Nearby Search (`fetchNearbyPOIs`), Place Details fetch (`fetchPlaceDetails`), campus center helper.
- `useOutdoorPOI.ts` — hook managing POI state: fetching on search, selection, address resolution via `reverseGeocodeAsync`, GPS position resolution.
- `OutdoorPOIInfoCard.tsx` — info card component for selected POIs.
- `MapScreen.tsx` — integrates everything: merged search results, marker rendering, `onPoiClick` for native POIs, map style toggling, directions flow.
- `useNavigationBetweenBuildings.ts` — extended with `openNavigationForCoordinate` for coordinate-based POI navigation.
 
Outdoor POIs are fully decoupled from buildings, indoor POIs, and `useSelectedBuilding`. Building taps only register when the user taps directly on a building's polygon — no snap-to-nearest-building behavior.
 
---
 
## New Test Coverage
 
### `outdoorPOIService.test.ts`
 
Covers category resolution (`isSupportedPOICategory`), fetching nearby POIs from the Google Maps API (`fetchNearbyPOIs`), fetching POI details (`fetchPlaceDetails`), and campus center logic (`getCampusCenterForPOI`), including API integration, error handling, and edge cases.
 
### `OutdoorPOIInfoCard.test.tsx`
 
Verifies correct rendering of POI details, handling of missing data, open/closed status display, category formatting, color-blind mode, and button interactions for closing and requesting directions.
 
### `useNavigationBetweenBuildings` hook tests (extended)
 
Covers the new `openNavigationForCoordinate` method, validating correct state updates for navigation destination, coordinate, and route type.